### PR TITLE
chore: fix codespaces devcontainer setup

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -7,7 +7,7 @@
     "ghcr.io/devcontainers/features/git:1": {}
   },
 
-  "onCreateCommand": "curl -fsSL https://bun.sh/install | bash && echo 'export PATH=\"$HOME/.bun/bin:$PATH\"' >> ~/.bashrc",
+  "onCreateCommand": "bash .devcontainer/on-create.sh",
   "postCreateCommand": "export PATH=\"$HOME/.bun/bin:$PATH\" && bun install && bunx playwright install --with-deps chromium",
 
   "forwardPorts": [4200],
@@ -38,10 +38,9 @@
         "esbenp.prettier-vscode"
       ],
       "settings": {
-        "terminal.integrated.defaultProfile.linux": "bash",
+        "terminal.integrated.defaultProfile.linux": "zsh",
         "editor.formatOnSave": true,
-        "editor.defaultFormatter": "esbenp.prettier-vscode",
-        "task.allowAutomaticTasks": "on"
+        "editor.defaultFormatter": "esbenp.prettier-vscode"
       }
     }
   },

--- a/.devcontainer/on-create.sh
+++ b/.devcontainer/on-create.sh
@@ -1,0 +1,30 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# --- Bun ---
+curl -fsSL https://bun.sh/install | bash
+echo 'export PATH="$HOME/.bun/bin:$PATH"' >> ~/.bashrc
+echo 'export PATH="$HOME/.bun/bin:$PATH"' >> ~/.zshrc
+
+# --- Copilot CLI ---
+if command -v copilot &>/dev/null; then
+  echo "✅ copilot CLI already installed"
+else
+  echo "Installing copilot CLI..."
+  curl -fsSL https://gh.io/copilot-install | bash
+fi
+
+# --- Copilot config (skip first-run prompts) ---
+COPILOT_CONFIG_DIR="$HOME/.copilot"
+COPILOT_CONFIG="$COPILOT_CONFIG_DIR/config.json"
+mkdir -p "$COPILOT_CONFIG_DIR"
+if [ ! -f "$COPILOT_CONFIG" ]; then
+  cat > "$COPILOT_CONFIG" << 'EOF'
+{
+  "banner": "never",
+  "trusted_folders": ["/workspaces"],
+  "firstLaunchAt": "2026-01-01T00:00:00.000Z"
+}
+EOF
+  echo "✅ copilot config pre-seeded"
+fi

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,4 +1,5 @@
 {
+  "task.allowAutomaticTasks": "on",
   "editor.defaultFormatter": "esbenp.prettier-vscode",
   "editor.formatOnSave": true,
   "editor.formatOnPaste": false,


### PR DESCRIPTION
- Switch default terminal from bash to zsh so dotfiles .zshrc writes take effect
- Move task.allowAutomaticTasks to .vscode/settings.json so VS Code reads it before remote customizations apply
- Extract onCreateCommand into on-create.sh; add Copilot CLI install and config pre-seeding
- Remove dependency on dotfiles repo for Codespaces setup