### PR TITLE
chore: add auto-work-issue GitHub agent file and unignore it

### DIFF
--- a/.github/agents/auto-work-issue.agent.md
+++ b/.github/agents/auto-work-issue.agent.md
@@ -1,0 +1,7 @@
+---
+name: auto-work-issue
+description: Autonomous 5-phase workflow for GitHub coding agent assignments. Runs comprehension, planning, implementation, verification, and reporting end-to-end without human phase gates. Posts progress to the GitHub issue and opens a PR when done.
+argument-hint: '[issue-number]'
+---
+
+Follow the instructions in `.agents/skills/auto-work-issue.md` exactly.

--- a/.gitignore
+++ b/.gitignore
@@ -59,6 +59,7 @@ test-output
 .agents/.planning-block-count
 
 # Tool-specific agent wrappers — contributors add their own locally
-.github/agents/
+.github/agents/*
+!.github/agents/auto-work-issue.agent.md
 .claude/
 package-lock.json


### PR DESCRIPTION
Follow-up to #114.

Creates `.github/agents/auto-work-issue.agent.md` so the skill is available as a committed Copilot CLI agent entry point.

Updates `.gitignore` to allow this specific file while keeping all other `.github/agents/` files local-only.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>