### PR TITLE
chore(82) + [api] scaffold @schediochron/api with Hono

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -61,10 +61,21 @@
     "apps/react-app": {
       "name": "@schediochron/react-app",
       "version": "0.1.1",
+      "dependencies": {
+        "@schediochron/react-components": "*",
+      },
     },
     "apps/react-app-e2e": {
       "name": "@schediochron/react-app-e2e",
       "version": "0.0.1",
+    },
+    "packages/api": {
+      "name": "@schediochron/api",
+      "version": "0.0.1",
+      "dependencies": {
+        "hono": "^4.12.0",
+        "tslib": "^2.3.0",
+      },
     },
     "packages/core": {
       "name": "@schediochron/core",
@@ -77,6 +88,10 @@
     "packages/react-components": {
       "name": "@schediochron/react-components",
       "version": "0.0.1",
+      "peerDependencies": {
+        "@schediochron/core": "*",
+        "react": ">=18.0.0",
+      },
     },
   },
   "trustedDependencies": [
@@ -691,6 +706,8 @@
     "@rspack/lite-tapable": ["@rspack/lite-tapable@1.1.0", "", {}, "sha512-E2B0JhYFmVAwdDiG14+DW0Di4Ze4Jg10Pc4/lILUrd5DRCaklduz2OvJ5HYQ6G+hd+WTzqQb3QnDNfK4yvAFYw=="],
 
     "@rtsao/scc": ["@rtsao/scc@1.1.0", "", {}, "sha512-zt6OdqaDoOnJ1ZYsCYGt9YmWzDXl4vQdKTyJev62gFhRGKdx7mcT54V9KIjg+d2wi9EXsPvAPKe7i7WjfVWB8g=="],
+
+    "@schediochron/api": ["@schediochron/api@workspace:packages/api"],
 
     "@schediochron/core": ["@schediochron/core@workspace:packages/core"],
 
@@ -1439,6 +1456,8 @@
     "hermes-parser": ["hermes-parser@0.25.1", "", { "dependencies": { "hermes-estree": "0.25.1" } }, "sha512-6pEjquH3rqaI6cYAXYPcz9MS4rY6R4ngRgrgfDshRptUZIc3lw0MCIJIGDj9++mfySOuPTHB4nrSW99BCvOPIA=="],
 
     "homedir-polyfill": ["homedir-polyfill@1.0.3", "", { "dependencies": { "parse-passwd": "^1.0.0" } }, "sha512-eSmmWE5bZTK2Nou4g0AI3zZ9rswp7GRKoKXS1BLUkvPviOqs4YTN1djQIqrXy9k5gEtdLPy86JjRwsNM9tnDcA=="],
+
+    "hono": ["hono@4.12.30", "", {}, "sha512-emn+JoJjrN9YTpRDS5it/UI2SO9BAE37T6I3d963RxcZ81G9A4pr2SZTEiiaiKbzx+NKRg5BZ89fCL7gCJCUog=="],
 
     "html-encoding-sniffer": ["html-encoding-sniffer@6.0.0", "", { "dependencies": { "@exodus/bytes": "^1.6.0" } }, "sha512-CV9TW3Y3f8/wT0BRFc1/KAVQ3TUHiXmaAb6VW9vtiMFf7SLoMd1PdAc4W3KFOFETBJUb90KatHqlsZMWV+R9Gg=="],
 

--- a/docs/adr/ADR-006-api-framework.md
+++ b/docs/adr/ADR-006-api-framework.md
@@ -1,0 +1,77 @@
+# ADR-006: API Framework
+
+**Status**: Accepted  
+**Date**: 2026-07-15  
+**Issue**: [#82 — scaffold `@schediochron/api` package and evaluate API framework](https://github.com/cyberniinja/schediochron/issues/82)
+
+---
+
+## Context
+
+The MVP needs a backend that implements the REST API contract defined in
+[ADR-005](./ADR-005-rest-api-contract.md) (`openapi.yaml`, OpenAPI 3.1). Before endpoint
+implementation can begin, the `@schediochron/api` package must exist and a framework must be
+chosen.
+
+The workspace already commits to a runtime and toolchain that constrain the decision:
+
+- **Bun** is the package manager and runtime (`bun.lock`, `bun@1.3.11`).
+- The codebase is **TypeScript-first** with strict compiler settings and ESM (`nodenext`).
+- `@schediochron/core` already uses **Zod** for model validation, and the API contract is an
+  **OpenAPI 3.1** document — so first-class Zod/OpenAPI integration is valuable for keeping the
+  implementation and the contract in sync.
+
+The framework should therefore be Bun-native, TypeScript-first, have a healthy middleware
+ecosystem, perform well, and — per the issue — leave the door open to a framework-agnostic
+adapter so we are not locked to a single runtime or hosting model.
+
+## Options Considered
+
+| Framework          | Bun support                     | TS-first                    | Runtime-agnostic                                             | Ecosystem                        | Notes                                                            |
+| ------------------ | ------------------------------- | --------------------------- | ----------------------------------------------------------- | -------------------------------- | --------------------------------------------------------------- |
+| **Hono**           | First-class (official adapter)  | Yes, excellent inference    | Yes — Web-standard `Request`/`Response`, adapters per runtime | Large, actively maintained       | `@hono/zod-openapi` binds Zod schemas to the OpenAPI contract   |
+| **Elysia**         | First-class (Bun-native)        | Yes, best-in-class          | No — tightly coupled to Bun                                  | Growing, smaller                 | Fastest on Bun, but Bun lock-in works against the adapter goal  |
+| **Express**        | Works via Node compat           | Types are add-on (`@types`) | Node-centric                                                 | Largest, mature                  | Callback-era design, no Web-standard primitives, weak TS story  |
+| **Fastify**        | Works via Node compat           | Good with plugins           | Node-centric                                                 | Large                            | Solid, but Node-oriented and heavier than needed for the MVP    |
+
+### Evaluation against the criteria
+
+- **Bun compatibility / native support** — Hono and Elysia both target Bun directly. Express and
+  Fastify run only through Bun's Node-compatibility layer, forgoing Web-standard primitives.
+- **TypeScript-first design** — Hono and Elysia are built around type inference; Express requires
+  external `@types`. Hono's inference is strong without the Bun coupling Elysia's brings.
+- **Middleware ecosystem** — Express has the largest ecosystem, but Hono ships a comprehensive
+  built-in middleware set (CORS, JWT, logger, compression) plus a first-party `@hono/*` line
+  including `@hono/zod-openapi` and `@hono/zod-validator`.
+- **Performance** — All four are adequate for the MVP. Elysia leads micro-benchmarks on Bun;
+  Hono is close behind and far ahead of Express. Performance is not a differentiator at this
+  scale.
+- **Community and ecosystem size** — Express is largest but legacy-shaped. Hono has strong,
+  current momentum and broad runtime coverage; Elysia is smaller and Bun-specific.
+- **Likelihood of a framework-agnostic adapter later** — This is the deciding factor. Hono is
+  built on Web-standard `Request`/`Response` and ships adapters for Bun, Node, Deno, Cloudflare
+  Workers, Vercel, and AWS Lambda. The same application object runs across runtimes with only the
+  entrypoint changed. Elysia optimises for Bun at the cost of portability.
+
+## Decision
+
+Use **[Hono](https://hono.dev)** for `@schediochron/api`.
+
+Hono is the only option that satisfies every criterion simultaneously: Bun-native, excellent
+TypeScript inference, a healthy middleware ecosystem, strong performance, and — decisively —
+runtime portability via Web-standard primitives. It also integrates cleanly with the existing
+Zod usage and the OpenAPI 3.1 contract through `@hono/zod-openapi`, which lets us derive
+request/response validation from the same schemas that document the API.
+
+The application is authored as a runtime-agnostic Hono instance (`app.ts`) exporting a standard
+`fetch` handler. The Bun entrypoint (`main.ts`) is a thin adapter. Moving to another runtime later
+means swapping the entrypoint, not rewriting the application.
+
+## Consequences
+
+- **Positive** — Portable across runtimes; strong types; contract-driven validation available via
+  `@hono/zod-openapi`; small dependency footprint; no Bun lock-in.
+- **Negative** — Smaller middleware ecosystem than Express; some Node-only libraries may need
+  Web-standard equivalents.
+- **Follow-up** — When implementing contract endpoints, adopt `@hono/zod-openapi` so routes are
+  validated against, and kept in sync with, `openapi.yaml`.

--- a/packages/api/README.md
+++ b/packages/api/README.md
@@ -1,0 +1,29 @@
+# api
+
+`@schediochron/api` — the backend HTTP API, built with [Hono](https://hono.dev) on Bun.
+
+The framework choice is documented in
+[ADR-006](../../docs/adr/ADR-006-api-framework.md), and the REST contract it implements in
+[ADR-005](../../docs/adr/ADR-005-rest-api-contract.md).
+
+## Running locally
+
+Run `nx serve @schediochron/api` to start the server with hot reload (defaults to
+`http://localhost:3000`; override with the `PORT` environment variable).
+
+Verify it is up:
+
+```sh
+curl http://localhost:3000/health
+# {"status":"ok","timestamp":"..."}
+```
+
+## Running unit tests
+
+Run `nx test @schediochron/api` to execute the unit tests via [Vitest](https://vitest.dev/).
+
+## Structure
+
+- `src/app.ts` — runtime-agnostic Hono application (routes/middleware).
+- `src/main.ts` — Bun entrypoint; the only runtime-specific glue.
+- `src/index.ts` — public package exports.

--- a/packages/api/eslint.config.mjs
+++ b/packages/api/eslint.config.mjs
@@ -1,0 +1,27 @@
+import baseConfig from '../../eslint.config.mjs';
+
+export default [
+  ...baseConfig,
+  {
+    files: ['**/*.json'],
+    rules: {
+      '@nx/dependency-checks': [
+        'error',
+        {
+          ignoredFiles: [
+            '{projectRoot}/eslint.config.{js,cjs,mjs,ts,cts,mts}',
+            '{projectRoot}/vite.config.{js,ts,mjs,mts}',
+            '{projectRoot}/vitest.config.{js,ts,mjs,mts}',
+            '{projectRoot}/src/**/*.{spec,test}.{js,ts,mjs,mts}',
+          ],
+        },
+      ],
+    },
+    languageOptions: {
+      parser: await import('jsonc-eslint-parser'),
+    },
+  },
+  {
+    ignores: ['**/out-tsc'],
+  },
+];

--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -1,0 +1,11 @@
+{
+  "name": "@schediochron/api",
+  "version": "0.0.1",
+  "private": true,
+  "type": "module",
+  "main": "./dist/main.js",
+  "dependencies": {
+    "hono": "^4.12.0",
+    "tslib": "^2.3.0"
+  }
+}

--- a/packages/api/project.json
+++ b/packages/api/project.json
@@ -1,0 +1,23 @@
+{
+  "name": "@schediochron/api",
+  "$schema": "../../node_modules/nx/schemas/project-schema.json",
+  "projectType": "application",
+  "sourceRoot": "packages/api/src",
+  "tags": [],
+  "targets": {
+    "serve": {
+      "executor": "nx:run-commands",
+      "options": {
+        "command": "bun run --watch src/main.ts",
+        "cwd": "packages/api"
+      }
+    },
+    "start": {
+      "executor": "nx:run-commands",
+      "options": {
+        "command": "bun run src/main.ts",
+        "cwd": "packages/api"
+      }
+    }
+  }
+}

--- a/packages/api/src/app.spec.ts
+++ b/packages/api/src/app.spec.ts
@@ -1,0 +1,14 @@
+import { describe, expect, it } from 'vitest';
+import { app } from './app.js';
+
+describe('GET /health', () => {
+  it('returns 200 with status ok', async () => {
+    const res = await app.request('/health');
+
+    expect(res.status).toBe(200);
+
+    const body = (await res.json()) as { status: string; timestamp: string };
+    expect(body.status).toBe('ok');
+    expect(typeof body.timestamp).toBe('string');
+  });
+});

--- a/packages/api/src/app.ts
+++ b/packages/api/src/app.ts
@@ -1,0 +1,12 @@
+import { Hono } from 'hono';
+
+/**
+ * The Hono application. Authored as a runtime-agnostic instance built on
+ * Web-standard `Request`/`Response` (see ADR-006). Runtime entrypoints such as
+ * `main.ts` adapt `app.fetch` to a concrete server.
+ */
+export const app = new Hono();
+
+app.get('/health', (c) =>
+  c.json({ status: 'ok', timestamp: new Date().toISOString() }),
+);

--- a/packages/api/src/index.ts
+++ b/packages/api/src/index.ts
@@ -1,0 +1,2 @@
+// Public API
+export { app } from './app.js';

--- a/packages/api/src/main.ts
+++ b/packages/api/src/main.ts
@@ -1,0 +1,11 @@
+import { app } from './app.js';
+
+const port = Number(process.env.PORT ?? 3000);
+
+// Bun picks up a default export exposing `fetch` and serves it automatically.
+// This is the only Bun-specific glue; the application itself (app.ts) is
+// runtime-agnostic (see ADR-006).
+export default {
+  port,
+  fetch: app.fetch,
+};

--- a/packages/api/tsconfig.json
+++ b/packages/api/tsconfig.json
@@ -1,0 +1,13 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "files": [],
+  "include": [],
+  "references": [
+    {
+      "path": "./tsconfig.lib.json"
+    },
+    {
+      "path": "./tsconfig.spec.json"
+    }
+  ]
+}

--- a/packages/api/tsconfig.lib.json
+++ b/packages/api/tsconfig.lib.json
@@ -1,0 +1,30 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "baseUrl": ".",
+    "rootDir": "src",
+    "outDir": "dist",
+    "tsBuildInfoFile": "dist/tsconfig.lib.tsbuildinfo",
+    "emitDeclarationOnly": false,
+    "module": "nodenext",
+    "moduleResolution": "nodenext",
+    "forceConsistentCasingInFileNames": true,
+    "types": ["node"]
+  },
+  "include": ["src/**/*.ts"],
+  "references": [],
+  "exclude": [
+    "vite.config.ts",
+    "vite.config.mts",
+    "vitest.config.ts",
+    "vitest.config.mts",
+    "src/**/*.test.ts",
+    "src/**/*.spec.ts",
+    "src/**/*.test.tsx",
+    "src/**/*.spec.tsx",
+    "src/**/*.test.js",
+    "src/**/*.spec.js",
+    "src/**/*.test.jsx",
+    "src/**/*.spec.jsx"
+  ]
+}

--- a/packages/api/tsconfig.spec.json
+++ b/packages/api/tsconfig.spec.json
@@ -1,0 +1,36 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "outDir": "./out-tsc/vitest",
+    "types": [
+      "vitest/globals",
+      "vitest/importMeta",
+      "vite/client",
+      "node",
+      "vitest"
+    ],
+    "module": "nodenext",
+    "moduleResolution": "nodenext",
+    "forceConsistentCasingInFileNames": true
+  },
+  "include": [
+    "vite.config.ts",
+    "vite.config.mts",
+    "vitest.config.ts",
+    "vitest.config.mts",
+    "src/**/*.test.ts",
+    "src/**/*.spec.ts",
+    "src/**/*.test.tsx",
+    "src/**/*.spec.tsx",
+    "src/**/*.test.js",
+    "src/**/*.spec.js",
+    "src/**/*.test.jsx",
+    "src/**/*.spec.jsx",
+    "src/**/*.d.ts"
+  ],
+  "references": [
+    {
+      "path": "./tsconfig.lib.json"
+    }
+  ]
+}

--- a/packages/api/vitest.config.mts
+++ b/packages/api/vitest.config.mts
@@ -1,0 +1,19 @@
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig(() => ({
+  root: __dirname,
+  cacheDir: '../../node_modules/.vite/packages/api',
+  test: {
+    name: '@schediochron/api',
+    watch: false,
+    globals: true,
+    environment: 'node',
+    include: ['{src,tests}/**/*.{test,spec}.{js,mjs,cjs,ts,mts,cts,jsx,tsx}'],
+    passWithNoTests: true,
+    reporters: ['default'],
+    coverage: {
+      reportsDirectory: './test-output/vitest/coverage',
+      provider: 'v8' as const,
+    },
+  },
+}));

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -18,6 +18,7 @@
     "target": "es2022",
     "customConditions": ["@schediochron/source"],
     "paths": {
+      "@schediochron/api": ["./packages/api/dist/index.d.ts"],
       "@schediochron/core": ["./packages/core/dist/index.d.ts"],
       "@schediochron/react-components": [
         "./packages/react-components/dist/index.d.ts"

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -10,6 +10,9 @@
       "path": "./apps/react-app"
     },
     {
+      "path": "./packages/api"
+    },
+    {
       "path": "./packages/core"
     },
     {


### PR DESCRIPTION
- add @schediochron/api package with a runtime-agnostic Hono app and a GET /health endpoint
- add ADR-006 documenting the API framework evaluation and the decision to use Hono
- split the app into app.ts (portable Hono instance) and main.ts (thin Bun entrypoint) so the runtime can be swapped without rewriting routes
- register the package with Nx (project.json serve/start targets) and wire it into the root tsconfig references and base paths