### PR TITLE
chore c [docs] refresh the roadmap's current state

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -65,17 +65,24 @@ Branch naming: `{type}/{issueNr}-{issue-name}`, where type is one of `feature`, 
 - No direct pushes to `main` — every change goes through a pull request.
 - Never merge a pull request. Merging is a human-only action: stop after opening the PR.
 
-### Roadmap
+### Roadmap and README
 
 [ROADMAP.md](ROADMAP.md) carries the vision, the module architecture every package is a piece of,
-and a description of where the codebase currently stands. It is what a newcomer reads first, and
-it goes stale silently — nothing fails when it drifts.
+and where the codebase currently stands. [README.md](README.md) carries the repository layout and
+the commands to run it. Between them they are what a newcomer reads first, and they go stale
+silently — nothing fails when they drift.
 
-So when a change makes part of it untrue, update it in the same change: a module lands, is renamed
-or moves between phases; the architecture table no longer matches the packages that exist; the
-"Current State" section describes work that is now done. Describe what is true now rather than
-appending a changelog. If you are unsure whether a change is roadmap-worthy, raise it instead of
-deciding silently — a roadmap nobody trusts is worse than no roadmap.
+So when a change makes part of them untrue, fix it in the same change:
+
+- a module lands, is renamed, or moves between phases
+- the architecture table or the structure block stops matching the packages and directories that
+  exist
+- a documented command changes, or the way the project is built, served or tested changes
+- "Current State" describes work that is now done
+
+Describe what is true now rather than appending a changelog. If you are unsure whether a change
+is worth documenting, raise it instead of deciding silently — docs nobody trusts are worse than
+no docs.
 
 Per-issue progress belongs on the project board and in GitHub issues; ROADMAP.md holds the
 narrative, not the checklist.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -38,7 +38,7 @@ bun run dev        # React dev server (http://localhost:4200)
 bun run dev:api    # API dev server (watch mode)
 bun run build      # Build all projects (dependency order)
 bun run typecheck  # tsc -b across all project references
-bun run test       # Unit/integration tests (Vitest)
+bun run test       # Unit/integration tests
 bun run e2e        # Playwright E2E — run `bun run build` first
 bun run lint       # ESLint (bun run lint:fix to auto-fix)
 bun run format     # Prettier

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -65,6 +65,21 @@ Branch naming: `{type}/{issueNr}-{issue-name}`, where type is one of `feature`, 
 - No direct pushes to `main` — every change goes through a pull request.
 - Never merge a pull request. Merging is a human-only action: stop after opening the PR.
 
+### Roadmap
+
+[ROADMAP.md](ROADMAP.md) carries the vision, the module architecture every package is a piece of,
+and a description of where the codebase currently stands. It is what a newcomer reads first, and
+it goes stale silently — nothing fails when it drifts.
+
+So when a change makes part of it untrue, update it in the same change: a module lands, is renamed
+or moves between phases; the architecture table no longer matches the packages that exist; the
+"Current State" section describes work that is now done. Describe what is true now rather than
+appending a changelog. If you are unsure whether a change is roadmap-worthy, raise it instead of
+deciding silently — a roadmap nobody trusts is worse than no roadmap.
+
+Per-issue progress belongs on the project board and in GitHub issues; ROADMAP.md holds the
+narrative, not the checklist.
+
 ### Package contents
 
 Each lib has a `files` allowlist in its `package.json`: whatever is not listed is not published,

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 Teams shouldn't have to pay for time management software. Schediochron provides everything you need to run your own time tracking system — pick only the parts you need, or use a pre-configured starter bundle to get running in minutes.
 
 > 📍 See [ROADMAP.md](ROADMAP.md) for the full vision and planned milestones.
-> 📋 Track progress on the [project board →](https://github.com/users/cyberniinja/projects/2)
+> 📋 Track progress on the [project board →](https://github.com/orgs/schediochron/projects/1)
 
 ---
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -116,7 +116,9 @@ Make Schediochron discoverable and easy to adopt.
 
 **Version:** 0.1.x (prototype)
 
-The current codebase is a React UI prototype demonstrating the calendar-based time tracking interface. It has no data persistence or backend. It will be split into `@schediochron/react-components` (component library) and `@schediochron/react-app` (full application) in Phase 1.
+The monorepo is structured around the module architecture above. `@schediochron/core` holds the data models and repository interfaces; the React prototype has been split into `@schediochron/react-components` (the reusable calendar and layout components) and `@schediochron/react-app` (the web UI built on them); and `@schediochron/api` is scaffolded on Hono, serving a health check against the REST contract in `libs/api/openapi.yaml`.
+
+Phase 1 finishes by stubbing out the API's routes from that contract, then running the validation gate. Persistence and real request handling arrive in Phase 2, when `@schediochron/sql` implements the `core` repository interfaces and the API is wired to it.
 
 ---
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -1,6 +1,6 @@
 # Schediochron Roadmap
 
-> **Track progress on the [Schediochron Roadmap project board →](https://github.com/users/cyberniinja/projects/2)**
+> **Track progress on the [Schediochron Roadmap project board →](https://github.com/orgs/schediochron/projects/1)**
 
 ---
 
@@ -126,4 +126,4 @@ Phase 1 finishes by stubbing out the API's routes from that contract, then runni
 
 See [CONTRIBUTING.md](./CONTRIBUTING.md) for how to get involved.
 Issues and feature requests are tracked on [GitHub Issues](https://github.com/schediochron/schediochron/issues).
-The full roadmap is maintained on the [project board](https://github.com/users/cyberniinja/projects/2).
+The full roadmap is maintained on the [project board](https://github.com/orgs/schediochron/projects/1).

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -125,5 +125,5 @@ Phase 1 finishes by stubbing out the API's routes from that contract, then runni
 ## Contributing
 
 See [CONTRIBUTING.md](./CONTRIBUTING.md) for how to get involved.
-Issues and feature requests are tracked on [GitHub Issues](https://github.com/cyberniinja/schediochron/issues).
+Issues and feature requests are tracked on [GitHub Issues](https://github.com/schediochron/schediochron/issues).
 The full roadmap is maintained on the [project board](https://github.com/users/cyberniinja/projects/2).

--- a/docs/adr/ADR-005-rest-api-contract.md
+++ b/docs/adr/ADR-005-rest-api-contract.md
@@ -2,7 +2,7 @@
 
 **Status**: Accepted  
 **Date**: 2026-03-26  
-**Issue**: [#17 — define MVP REST API contract (OpenAPI spec)](https://github.com/cyberniinja/schediochron/issues/17)
+**Issue**: [#17 — define MVP REST API contract (OpenAPI spec)](https://github.com/schediochron/schediochron/issues/17)
 
 ---
 

--- a/docs/adr/ADR-006-api-framework.md
+++ b/docs/adr/ADR-006-api-framework.md
@@ -2,7 +2,7 @@
 
 **Status**: Accepted  
 **Date**: 2026-07-15  
-**Issue**: [#82 — scaffold `@schediochron/api` package and evaluate API framework](https://github.com/cyberniinja/schediochron/issues/82)
+**Issue**: [#82 — scaffold `@schediochron/api` package and evaluate API framework](https://github.com/schediochron/schediochron/issues/82)
 
 ---
 

--- a/docs/adr/ADR-007-release-and-publishing.md
+++ b/docs/adr/ADR-007-release-and-publishing.md
@@ -1,0 +1,112 @@
+# ADR-007: Release and Publishing
+
+**Status**: Accepted  
+**Date**: 2026-07-16  
+**Issue**: [#69 — define and automate the public release process](https://github.com/schediochron/schediochron/issues/69)
+
+---
+
+## Context
+
+Schediochron is built to be consumed as independently installable packages — that modularity is
+the product, not an implementation detail. So how versions are cut, what they mean together, and
+where they are distributed are decisions the architecture depends on.
+
+Three things forced the question now:
+
+- **Release automation was removed.** The repo ran [Release Please](https://github.com/googleapis/release-please),
+  which cut `schediochron@v0.1.0` and `v0.1.1` in March 2026 and then produced nothing for four
+  months while substantial work landed. It was configured to watch a single package
+  (`apps/react-app`), so `core`, `react-components` and `api` were never releasable through it,
+  and it derives versions from [Conventional Commits](https://www.conventionalcommits.org), which
+  this project's commit convention does not follow. It ran green on every merge and did nothing.
+- **Nothing is published yet.** Every package is `private: true`. Inside the workspace,
+  `workspace:^` resolves internal dependencies, and the starter bundles will live in this repo
+  too — so no registry is needed until something outside the repo installs a package, which is a
+  Phase 5 concern.
+- **Releases are wanted now, for history.** Phase completions should be tagged and downloadable
+  as a record of how the project evolved. That need is independent of distribution.
+
+## Decision
+
+### 1. A release and a publish are separate things
+
+A **release** is a git tag plus a GitHub Release: the historical record. A **publish** pushes
+tarballs to a registry: distribution. They are decoupled, and only the first is needed today.
+
+Tag phase completions as `vX.Y.Z` and title the release for the phase it closes (e.g.
+`v0.2.0 — Phase 1: Architecture Foundation`). GitHub generates the source archives for every tag
+automatically; nothing needs building or uploading for the snapshot to exist permanently.
+
+Tags are versions and carry no other meaning — the phase belongs in the release title. This
+supersedes the `schediochron@vX.Y.Z` tag format, which was an artifact of Release Please's
+`include-component-in-tag` setting for a single watched package.
+
+### 2. Publish to npm, not GitHub Packages, when the time comes
+
+GitHub Packages was considered as an interim registry and rejected on two counts:
+
+- **The scope must equal the owning account**, so packages would publish as `@cyberniinja/*` —
+  or, after the org move, `@schediochron/*` only because the GitHub org happens to share the
+  name. Publishing under a name we do not intend to keep is not a rehearsal of anything.
+- **Installing a public package requires a token.** GitHub's docs: _"You need an access token to
+  publish, install, and delete private, internal, and public packages."_ Requiring every consumer
+  to hold a PAT and configure `.npmrc` contradicts the project's central promise of frictionless
+  self-hosting.
+
+npm is public, anonymous to install, and is the name we actually want. The `@schediochron` org is
+reserved there. (This applies to the npm registry only: `ghcr.io` allows anonymous pulls, so
+GitHub remains the sensible home for the Phase 5 Docker images.)
+
+### 3. Lockstep versioning across `@schediochron/*`
+
+All packages share one version. A release means "everything at 1.3.0 works together".
+
+The alternative — independent per-package versions — is more honest about what changed, but it
+produces a compatibility matrix that someone has to maintain and consumers have to read. Since
+starter bundles compose many packages at once, a single family version turns compatibility into
+a fact rather than documentation. The earlier releases were already single-versioned.
+
+### 4. No release tooling until publishing exists; then Changesets if warranted
+
+Release Please was removed because it was ceremony without a product. Adopting a replacement now
+would repeat that mistake, so releases are cut by hand: bump, write notes, tag, publish the
+GitHub Release.
+
+When tooling is warranted, use [Changesets](https://github.com/changesets/changesets) rather than
+a commit-parsing tool. This follows directly from the commit convention: Changesets ignores commit
+history and takes a per-PR note instead, which also means release notes get written while the
+context is fresh and are reviewed in the diff — rather than reconstructed from commit archaeology
+at release time. Verify its Bun compatibility before adopting it.
+
+## Consequences
+
+The publish cycle, once npm is live, is today's release ritual plus one step:
+
+1. Bump every `@schediochron/*` to the same version
+2. Write the notes into `CHANGELOG.md`
+3. PR → merge → tag `vX.Y.Z`
+4. GitHub Release from the tag (source archives automatic)
+5. **New:** CI publishes each package on the tag
+
+Starting the tag-and-release habit now is therefore not a detour — it is the release process
+minus its last line.
+
+**Already in place:** `bun publish` rewrites `workspace:^` to a real caret range on the way out
+(same rewriting `bun pm pack` performs), so internal dependencies need no special handling at
+publish time; each lib's `files` allowlist already controls its payload.
+
+**Prerequisites for the first publish:**
+
+- Remove `private: true` from the packages to be published
+- Add `"publishConfig": { "access": "public" }` — npm's docs: _"Scoped packages are private by
+  default; you must pass a command-line flag when publishing to make them public"_
+- Add a `repository` field per package (npm links it, and provenance attests against it)
+- Reach `1.0.0` first if deduplication matters: caret does not widen below 1.0, so `^0.0.1`
+  resolves to exactly `0.0.1` and consumers on different patches get duplicate copies
+- Decide provenance. `bun publish` has no `--provenance` flag, so npm provenance via GitHub OIDC
+  would make that job call `npm publish --provenance` instead. Nothing needs deciding until the
+  workflow is written; it is not a one-way door.
+
+**Follow-up:** #69's acceptance criteria still assume Release Please generates changelogs and
+version bumps, and need rewriting against this ADR.


### PR DESCRIPTION
Docs catch-up for everything that landed around the toolchain rebuild and the org move, plus the release decisions that kept coming up.

**ROADMAP's Current State** described the prototype split as upcoming work. It shipped in #70, so the section now describes where the codebase actually is, and what closes out Phase 1.

**A rule so it stops happening.** These docs drift because nothing fails when they are wrong — no build breaks, no test goes red. AGENTS.md now makes fixing **ROADMAP.md and README.md** part of the change that dates them: a module lands or is renamed, the architecture table or structure block stops matching the directories that exist, a documented command changes, or "Current State" describes finished work. Ask rather than decide silently when it is unclear. (It immediately caught one: the commands list still credited Vitest.)

**The org move.** Repo links and the project board links now name `schediochron/schediochron` and the org project rather than relying on GitHub's redirect. The board was recreated under the org — a user project does not follow a repo transfer — with all 81 issues and their statuses; the old board is closed, not deleted. `apps/react-app/CHANGELOG.md` keeps its old URLs on purpose: it is a historical record of the v0.1.x releases and its links resolve through the redirect.

**ADR-007: Release and Publishing** records decisions that would otherwise be re-litigated: releases (tags, for history, wanted now) are separate from publishing (registry, Phase 5); npm over GitHub Packages, which requires a token to install even public packages; lockstep versioning; no release tooling until there is something to publish, and Changesets over a commit-parsing tool when there is — Release Please derived versions from a commit convention this project does not follow, which is why it cut nothing for four months. It also captures the first-publish prerequisites while they are fresh: `access: public`, `repository` fields, the 0.x caret trap, and the provenance choice.

Follow-up not in this PR: #69's criteria still assume "Release-Please (already configured)".

Docs only; no code changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)