### PR TITLE
feature(83) + [api] implement stub routes from the OpenAPI contract

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -116,9 +116,9 @@ Make Schediochron discoverable and easy to adopt.
 
 **Version:** 0.1.x (prototype)
 
-The monorepo is structured around the module architecture above. `@schediochron/core` holds the data models and repository interfaces; the React prototype has been split into `@schediochron/react-components` (the reusable calendar and layout components) and `@schediochron/react-app` (the web UI built on them); and `@schediochron/api` is scaffolded on Hono, serving a health check against the REST contract in `libs/api/openapi.yaml`.
+The monorepo is structured around the module architecture above. `@schediochron/core` holds the data models, repository interfaces and the wire contract types; the React prototype has been split into `@schediochron/react-components` (the reusable calendar and layout components) and `@schediochron/react-app` (the web UI built on them); and `@schediochron/api` routes every endpoint of the REST contract in `libs/api/openapi.yaml` on Hono, answering with stub payloads.
 
-Phase 1 finishes by stubbing out the API's routes from that contract, then running the validation gate. Persistence and real request handling arrive in Phase 2, when `@schediochron/sql` implements the `core` repository interfaces and the API is wired to it.
+Phase 1 finishes by running the validation gate over that architecture. Persistence and real request handling arrive in Phase 2, when `@schediochron/sql` implements the `core` repository interfaces, the API is wired to it, and authentication and request validation replace the stubs.
 
 ---
 

--- a/bun.lock
+++ b/bun.lock
@@ -47,6 +47,7 @@
       "name": "@schediochron/api",
       "version": "0.0.1",
       "dependencies": {
+        "@schediochron/core": "workspace:^",
         "hono": "^4.12.0",
         "tslib": "^2.3.0",
       },

--- a/libs/api/README.md
+++ b/libs/api/README.md
@@ -29,11 +29,21 @@ curl http://localhost:3000/health
 bun run --filter @schediochron/api test
 ```
 
-Tests run on [Vitest](https://vitest.dev/).
+Tests run on [`bun test`](https://bun.com/docs/cli/test).
 
 ## Structure
 
-- `src/app.ts` — runtime-agnostic Hono application (routes/middleware).
+- `src/app.ts` — runtime-agnostic Hono application; mounts the routes and the error envelope.
+- `src/routes/` — one module per resource group, mirroring the tags in `openapi.yaml`.
+- `src/stub-data.ts` — the sample payloads the stub routes return.
 - `src/main.ts` — Bun entrypoint; the only runtime-specific glue.
 - `src/index.ts` — public package exports.
 - `openapi.yaml` — the REST contract this package implements.
+
+## Status
+
+Every operation in `openapi.yaml` is routed, but the handlers are stubs: they return fixed
+payloads from `src/stub-data.ts`, shaped like the real responses and typed with
+`@schediochron/core`. Authentication, authorisation and request validation are not implemented —
+every endpoint answers as though the caller were authorised — and arrive in Phase 2 along with
+persistence.

--- a/libs/api/package.json
+++ b/libs/api/package.json
@@ -19,6 +19,7 @@
     "test:watch": "bun test --watch"
   },
   "dependencies": {
+    "@schediochron/core": "workspace:^",
     "hono": "^4.12.0",
     "tslib": "^2.3.0"
   }

--- a/libs/api/src/app.spec.ts
+++ b/libs/api/src/app.spec.ts
@@ -12,3 +12,119 @@ describe('GET /health', () => {
     expect(typeof body.timestamp).toBe('string');
   });
 });
+
+/**
+ * Every operation in `openapi.yaml`, with the success status it documents.
+ * A route that is missing, mounted on the wrong path, or bound to the wrong
+ * method fails here rather than in the per-resource shape specs.
+ */
+const operations = [
+  { id: 'registerUser', method: 'POST', path: '/auth/register', status: 201 },
+  { id: 'loginUser', method: 'POST', path: '/auth/login', status: 200 },
+  { id: 'refreshToken', method: 'POST', path: '/auth/refresh', status: 200 },
+  { id: 'logoutUser', method: 'POST', path: '/auth/logout', status: 204 },
+
+  { id: 'listUsers', method: 'GET', path: '/users', status: 200 },
+  { id: 'getUser', method: 'GET', path: '/users/u-1', status: 200 },
+  { id: 'updateUser', method: 'PATCH', path: '/users/u-1', status: 200 },
+  {
+    id: 'adminResetPassword',
+    method: 'PATCH',
+    path: '/users/u-1/password',
+    status: 204,
+  },
+
+  { id: 'listTimeEntries', method: 'GET', path: '/time-entries', status: 200 },
+  { id: 'createTimeEntry', method: 'POST', path: '/time-entries', status: 201 },
+  {
+    id: 'startTimeEntry',
+    method: 'POST',
+    path: '/time-entries/start',
+    status: 201,
+  },
+  {
+    id: 'stopTimeEntry',
+    method: 'POST',
+    path: '/time-entries/stop',
+    status: 200,
+  },
+  { id: 'getTimeEntry', method: 'GET', path: '/time-entries/e-1', status: 200 },
+  {
+    id: 'updateTimeEntry',
+    method: 'PATCH',
+    path: '/time-entries/e-1',
+    status: 200,
+  },
+  {
+    id: 'deleteTimeEntry',
+    method: 'DELETE',
+    path: '/time-entries/e-1',
+    status: 204,
+  },
+
+  { id: 'listTeams', method: 'GET', path: '/teams', status: 200 },
+  { id: 'createTeam', method: 'POST', path: '/teams', status: 201 },
+  { id: 'getTeam', method: 'GET', path: '/teams/t-1', status: 200 },
+  { id: 'updateTeam', method: 'PATCH', path: '/teams/t-1', status: 200 },
+  { id: 'deleteTeam', method: 'DELETE', path: '/teams/t-1', status: 204 },
+  {
+    id: 'addTeamMember',
+    method: 'POST',
+    path: '/teams/t-1/members',
+    status: 200,
+  },
+  {
+    id: 'removeTeamMember',
+    method: 'DELETE',
+    path: '/teams/t-1/members/u-2',
+    status: 200,
+  },
+
+  { id: 'getHoursReport', method: 'GET', path: '/reports/hours', status: 200 },
+] as const;
+
+describe('openapi.yaml operations', () => {
+  it('covers every documented operation', () => {
+    // Guards against an endpoint being dropped from the table along with its route.
+    expect(operations).toHaveLength(23);
+  });
+
+  for (const { id, method, path, status } of operations) {
+    it(`${id}: ${method} ${path} → ${status}`, async () => {
+      const res = await app.request(path, { method });
+      expect(res.status).toBe(status);
+    });
+  }
+
+  for (const { id, method, path, status } of operations) {
+    if (status === 204) {
+      it(`${id}: ${method} ${path} sends no body`, async () => {
+        const res = await app.request(path, { method });
+        expect(await res.text()).toBe('');
+      });
+    } else {
+      it(`${id}: ${method} ${path} sends JSON`, async () => {
+        const res = await app.request(path, { method });
+        expect(res.headers.get('content-type')).toContain('application/json');
+      });
+    }
+  }
+});
+
+describe('unrouted requests', () => {
+  it('returns the ErrorResponse envelope for an unknown path', async () => {
+    const res = await app.request('/nope');
+
+    expect(res.status).toBe(404);
+    expect(res.headers.get('content-type')).toContain('application/json');
+
+    const body = (await res.json()) as { error: string };
+    expect(typeof body.error).toBe('string');
+  });
+
+  it('returns 404 for a method the path does not define', async () => {
+    const res = await app.request('/auth/register', { method: 'DELETE' });
+
+    expect(res.status).toBe(404);
+  });
+});

--- a/libs/api/src/app.ts
+++ b/libs/api/src/app.ts
@@ -1,12 +1,41 @@
 import { Hono } from 'hono';
+import type { ErrorResponse } from '@schediochron/core';
+import { authRoutes } from './routes/auth.js';
+import { reportRoutes } from './routes/reports.js';
+import { teamRoutes } from './routes/teams.js';
+import { timeEntryRoutes } from './routes/time-entries.js';
+import { userRoutes } from './routes/users.js';
 
 /**
  * The Hono application. Authored as a runtime-agnostic instance built on
  * Web-standard `Request`/`Response` (see ADR-006). Runtime entrypoints such as
  * `main.ts` adapt `app.fetch` to a concrete server.
+ *
+ * Routes mirror `openapi.yaml` and currently return stub payloads (#83).
+ * Authentication and request validation land in Phase 2 (#71), so for now every
+ * endpoint answers as though the caller were authorised.
  */
 export const app = new Hono();
 
 app.get('/health', (c) =>
   c.json({ status: 'ok', timestamp: new Date().toISOString() }),
 );
+
+app.route('/auth', authRoutes);
+app.route('/users', userRoutes);
+app.route('/time-entries', timeEntryRoutes);
+app.route('/teams', teamRoutes);
+app.route('/reports', reportRoutes);
+
+// The contract specifies the ErrorResponse envelope for every 4xx and 5xx, so
+// unrouted paths and uncaught throws answer in it too rather than in Hono's
+// plain-text defaults.
+app.notFound((c) => {
+  const body: ErrorResponse = { error: 'Not found' };
+  return c.json(body, 404);
+});
+
+app.onError((_err, c) => {
+  const body: ErrorResponse = { error: 'Internal server error' };
+  return c.json(body, 500);
+});

--- a/libs/api/src/routes/auth.spec.ts
+++ b/libs/api/src/routes/auth.spec.ts
@@ -1,0 +1,36 @@
+import { describe, expect, it } from 'bun:test';
+import { validateUser } from '@schediochron/core';
+import { app } from '../app.js';
+
+describe('POST /auth/register', () => {
+  it('returns a valid user and a token pair', async () => {
+    const res = await app.request('/auth/register', { method: 'POST' });
+    const body = (await res.json()) as Record<string, unknown>;
+
+    expect(validateUser(body['user']).success).toBe(true);
+    expect(typeof body['accessToken']).toBe('string');
+    expect(typeof body['refreshToken']).toBe('string');
+  });
+});
+
+describe('POST /auth/login', () => {
+  it('returns a valid user and a token pair', async () => {
+    const res = await app.request('/auth/login', { method: 'POST' });
+    const body = (await res.json()) as Record<string, unknown>;
+
+    expect(validateUser(body['user']).success).toBe(true);
+    expect(typeof body['accessToken']).toBe('string');
+    expect(typeof body['refreshToken']).toBe('string');
+  });
+});
+
+describe('POST /auth/refresh', () => {
+  it('returns a token pair without a user', async () => {
+    const res = await app.request('/auth/refresh', { method: 'POST' });
+    const body = (await res.json()) as Record<string, unknown>;
+
+    expect(typeof body['accessToken']).toBe('string');
+    expect(typeof body['refreshToken']).toBe('string');
+    expect(body['user']).toBeUndefined();
+  });
+});

--- a/libs/api/src/routes/auth.ts
+++ b/libs/api/src/routes/auth.ts
@@ -1,0 +1,16 @@
+import { Hono } from 'hono';
+import type { AuthResponse } from '@schediochron/core';
+import { stubTokenPair, stubUser } from '../stub-data.js';
+
+/** `/auth` — authentication and token management. Stub responses (#83). */
+export const authRoutes = new Hono();
+
+const authResponse: AuthResponse = { user: stubUser, ...stubTokenPair };
+
+authRoutes.post('/register', (c) => c.json(authResponse, 201));
+
+authRoutes.post('/login', (c) => c.json(authResponse, 200));
+
+authRoutes.post('/refresh', (c) => c.json(stubTokenPair, 200));
+
+authRoutes.post('/logout', (c) => c.body(null, 204));

--- a/libs/api/src/routes/reports.spec.ts
+++ b/libs/api/src/routes/reports.spec.ts
@@ -1,0 +1,48 @@
+import { describe, expect, it } from 'bun:test';
+import { computeDuration, validateTimeEntry } from '@schediochron/core';
+import type { TimeEntry } from '@schediochron/core';
+import { app } from '../app.js';
+
+describe('GET /reports/hours', () => {
+  it('returns an array of daily summaries', async () => {
+    const res = await app.request('/reports/hours');
+    const body = (await res.json()) as unknown[];
+
+    expect(Array.isArray(body)).toBe(true);
+    expect(body.length).toBeGreaterThan(0);
+  });
+
+  it('shapes each day as date, totalMinutes and valid entries', async () => {
+    const res = await app.request('/reports/hours');
+    const body = (await res.json()) as {
+      date: string;
+      totalMinutes: number;
+      entries: unknown[];
+    }[];
+
+    for (const day of body) {
+      expect(day.date).toMatch(/^\d{4}-\d{2}-\d{2}$/);
+      expect(Number.isInteger(day.totalMinutes)).toBe(true);
+      expect(day.totalMinutes).toBeGreaterThanOrEqual(0);
+      for (const entry of day.entries) {
+        expect(validateTimeEntry(entry).success).toBe(true);
+      }
+    }
+  });
+
+  it('reports totalMinutes consistent with the entries it lists', async () => {
+    const res = await app.request('/reports/hours');
+    const body = (await res.json()) as {
+      totalMinutes: number;
+      entries: TimeEntry[];
+    }[];
+
+    for (const day of body) {
+      const summed = day.entries.reduce(
+        (total, entry) => total + (computeDuration(entry) ?? 0) / 60_000,
+        0,
+      );
+      expect(summed).toBe(day.totalMinutes);
+    }
+  });
+});

--- a/libs/api/src/routes/reports.ts
+++ b/libs/api/src/routes/reports.ts
@@ -1,0 +1,7 @@
+import { Hono } from 'hono';
+import { stubHoursReportDay } from '../stub-data.js';
+
+/** `/reports` — hours reporting. Stub responses (#83). */
+export const reportRoutes = new Hono();
+
+reportRoutes.get('/hours', (c) => c.json([stubHoursReportDay], 200));

--- a/libs/api/src/routes/teams.spec.ts
+++ b/libs/api/src/routes/teams.spec.ts
@@ -1,0 +1,68 @@
+import { describe, expect, it } from 'bun:test';
+import { validateTeam } from '@schediochron/core';
+import { app } from '../app.js';
+
+const id = '77777777-7777-4777-8777-777777777777';
+
+describe('GET /teams', () => {
+  it('returns an array of valid teams', async () => {
+    const res = await app.request('/teams');
+    const body = (await res.json()) as unknown[];
+
+    expect(Array.isArray(body)).toBe(true);
+    expect(body.length).toBeGreaterThan(0);
+    for (const team of body) {
+      expect(validateTeam(team).success).toBe(true);
+    }
+  });
+});
+
+describe('POST /teams', () => {
+  it('returns a valid team', async () => {
+    const res = await app.request('/teams', { method: 'POST' });
+
+    expect(validateTeam(await res.json()).success).toBe(true);
+  });
+});
+
+describe('GET /teams/:id', () => {
+  it('returns a valid team carrying the requested id', async () => {
+    const res = await app.request(`/teams/${id}`);
+    const body = (await res.json()) as { id: string };
+
+    expect(validateTeam(body).success).toBe(true);
+    expect(body.id).toBe(id);
+  });
+});
+
+describe('PATCH /teams/:id', () => {
+  it('returns a valid team carrying the requested id', async () => {
+    const res = await app.request(`/teams/${id}`, { method: 'PATCH' });
+    const body = (await res.json()) as { id: string };
+
+    expect(validateTeam(body).success).toBe(true);
+    expect(body.id).toBe(id);
+  });
+});
+
+describe('POST /teams/:id/members', () => {
+  it('returns the updated team', async () => {
+    const res = await app.request(`/teams/${id}/members`, { method: 'POST' });
+    const body = (await res.json()) as { id: string };
+
+    expect(validateTeam(body).success).toBe(true);
+    expect(body.id).toBe(id);
+  });
+});
+
+describe('DELETE /teams/:id/members/:userId', () => {
+  it('returns the updated team', async () => {
+    const res = await app.request(`/teams/${id}/members/u-2`, {
+      method: 'DELETE',
+    });
+    const body = (await res.json()) as { id: string };
+
+    expect(validateTeam(body).success).toBe(true);
+    expect(body.id).toBe(id);
+  });
+});

--- a/libs/api/src/routes/teams.ts
+++ b/libs/api/src/routes/teams.ts
@@ -1,0 +1,26 @@
+import { Hono } from 'hono';
+import type { Team } from '@schediochron/core';
+import { stubTeam } from '../stub-data.js';
+
+/** `/teams` — team management and membership. Stub responses (#83). */
+export const teamRoutes = new Hono();
+
+const teamWithId = (id: string): Team => ({ ...stubTeam, id });
+
+teamRoutes.get('/', (c) => c.json([stubTeam], 200));
+
+teamRoutes.post('/', (c) => c.json(stubTeam, 201));
+
+teamRoutes.get('/:id', (c) => c.json(teamWithId(c.req.param('id')), 200));
+
+teamRoutes.patch('/:id', (c) => c.json(teamWithId(c.req.param('id')), 200));
+
+teamRoutes.delete('/:id', (c) => c.body(null, 204));
+
+teamRoutes.post('/:id/members', (c) =>
+  c.json(teamWithId(c.req.param('id')), 200),
+);
+
+teamRoutes.delete('/:id/members/:userId', (c) =>
+  c.json(teamWithId(c.req.param('id')), 200),
+);

--- a/libs/api/src/routes/time-entries.spec.ts
+++ b/libs/api/src/routes/time-entries.spec.ts
@@ -1,0 +1,76 @@
+import { describe, expect, it } from 'bun:test';
+import { validateTimeEntry } from '@schediochron/core';
+import { app } from '../app.js';
+
+const id = '88888888-8888-4888-8888-888888888888';
+
+describe('GET /time-entries', () => {
+  it('returns an array of valid entries', async () => {
+    const res = await app.request('/time-entries');
+    const body = (await res.json()) as unknown[];
+
+    expect(Array.isArray(body)).toBe(true);
+    expect(body.length).toBeGreaterThan(0);
+    for (const entry of body) {
+      expect(validateTimeEntry(entry).success).toBe(true);
+    }
+  });
+});
+
+describe('POST /time-entries', () => {
+  it('returns a valid completed entry', async () => {
+    const res = await app.request('/time-entries', { method: 'POST' });
+    const body = (await res.json()) as { status: string };
+
+    expect(validateTimeEntry(body).success).toBe(true);
+    expect(body.status).toBe('completed');
+  });
+});
+
+describe('POST /time-entries/start', () => {
+  it('returns a valid running entry', async () => {
+    const res = await app.request('/time-entries/start', { method: 'POST' });
+    const body = (await res.json()) as {
+      status: string;
+      endTime: string | null;
+    };
+
+    expect(validateTimeEntry(body).success).toBe(true);
+    expect(body.status).toBe('running');
+    expect(body.endTime).toBeNull();
+  });
+});
+
+describe('POST /time-entries/stop', () => {
+  it('returns a valid completed entry', async () => {
+    const res = await app.request('/time-entries/stop', { method: 'POST' });
+    const body = (await res.json()) as {
+      status: string;
+      endTime: string | null;
+    };
+
+    expect(validateTimeEntry(body).success).toBe(true);
+    expect(body.status).toBe('completed');
+    expect(body.endTime).not.toBeNull();
+  });
+});
+
+describe('GET /time-entries/:id', () => {
+  it('returns a valid entry carrying the requested id', async () => {
+    const res = await app.request(`/time-entries/${id}`);
+    const body = (await res.json()) as { id: string };
+
+    expect(validateTimeEntry(body).success).toBe(true);
+    expect(body.id).toBe(id);
+  });
+});
+
+describe('PATCH /time-entries/:id', () => {
+  it('returns a valid entry carrying the requested id', async () => {
+    const res = await app.request(`/time-entries/${id}`, { method: 'PATCH' });
+    const body = (await res.json()) as { id: string };
+
+    expect(validateTimeEntry(body).success).toBe(true);
+    expect(body.id).toBe(id);
+  });
+});

--- a/libs/api/src/routes/time-entries.ts
+++ b/libs/api/src/routes/time-entries.ts
@@ -1,0 +1,26 @@
+import { Hono } from 'hono';
+import type { TimeEntry } from '@schediochron/core';
+import { stubCompletedEntry, stubRunningEntry } from '../stub-data.js';
+
+/** `/time-entries` — manual entries and clock-in/clock-out. Stub responses (#83). */
+export const timeEntryRoutes = new Hono();
+
+const entryWithId = (id: string): TimeEntry => ({ ...stubCompletedEntry, id });
+
+timeEntryRoutes.get('/', (c) =>
+  c.json([stubCompletedEntry, stubRunningEntry], 200),
+);
+
+timeEntryRoutes.post('/', (c) => c.json(stubCompletedEntry, 201));
+
+timeEntryRoutes.post('/start', (c) => c.json(stubRunningEntry, 201));
+
+timeEntryRoutes.post('/stop', (c) => c.json(stubCompletedEntry, 200));
+
+timeEntryRoutes.get('/:id', (c) => c.json(entryWithId(c.req.param('id')), 200));
+
+timeEntryRoutes.patch('/:id', (c) =>
+  c.json(entryWithId(c.req.param('id')), 200),
+);
+
+timeEntryRoutes.delete('/:id', (c) => c.body(null, 204));

--- a/libs/api/src/routes/users.spec.ts
+++ b/libs/api/src/routes/users.spec.ts
@@ -1,0 +1,38 @@
+import { describe, expect, it } from 'bun:test';
+import { validateUser } from '@schediochron/core';
+import { app } from '../app.js';
+
+const id = '99999999-9999-4999-8999-999999999999';
+
+describe('GET /users', () => {
+  it('returns an array of valid users', async () => {
+    const res = await app.request('/users');
+    const body = (await res.json()) as unknown[];
+
+    expect(Array.isArray(body)).toBe(true);
+    expect(body.length).toBeGreaterThan(0);
+    for (const user of body) {
+      expect(validateUser(user).success).toBe(true);
+    }
+  });
+});
+
+describe('GET /users/:id', () => {
+  it('returns a valid user carrying the requested id', async () => {
+    const res = await app.request(`/users/${id}`);
+    const body = (await res.json()) as { id: string };
+
+    expect(validateUser(body).success).toBe(true);
+    expect(body.id).toBe(id);
+  });
+});
+
+describe('PATCH /users/:id', () => {
+  it('returns a valid user carrying the requested id', async () => {
+    const res = await app.request(`/users/${id}`, { method: 'PATCH' });
+    const body = (await res.json()) as { id: string };
+
+    expect(validateUser(body).success).toBe(true);
+    expect(body.id).toBe(id);
+  });
+});

--- a/libs/api/src/routes/users.ts
+++ b/libs/api/src/routes/users.ts
@@ -1,0 +1,18 @@
+import { Hono } from 'hono';
+import type { User } from '@schediochron/core';
+import { stubUser } from '../stub-data.js';
+
+/** `/users` — user management. Stub responses (#83). */
+export const userRoutes = new Hono();
+
+// The requested id is echoed back so the stub reflects the path it was reached
+// through; Phase 2 looks the user up instead.
+const userWithId = (id: string): User => ({ ...stubUser, id });
+
+userRoutes.get('/', (c) => c.json([stubUser], 200));
+
+userRoutes.get('/:id', (c) => c.json(userWithId(c.req.param('id')), 200));
+
+userRoutes.patch('/:id', (c) => c.json(userWithId(c.req.param('id')), 200));
+
+userRoutes.patch('/:id/password', (c) => c.body(null, 204));

--- a/libs/api/src/stub-data.ts
+++ b/libs/api/src/stub-data.ts
@@ -1,0 +1,68 @@
+import type {
+  HoursReportDay,
+  Team,
+  TimeEntry,
+  TokenPair,
+  User,
+} from '@schediochron/core';
+
+/**
+ * Fixed sample payloads backing the stub routes, shaped exactly like the real
+ * responses will be (see `openapi.yaml`). Phase 2 replaces these with data from
+ * the repositories in `@schediochron/core`; nothing outside the route handlers
+ * should depend on them.
+ *
+ * Values are constant rather than generated so responses stay deterministic.
+ */
+
+export const stubUser: User = {
+  id: '11111111-1111-4111-8111-111111111111',
+  username: 'ada',
+  displayName: 'Ada Lovelace',
+  email: 'ada@example.com',
+  role: 'admin',
+  createdAt: '2026-01-05T08:00:00Z',
+  updatedAt: '2026-01-05T08:00:00Z',
+};
+
+export const stubTokenPair: TokenPair = {
+  accessToken: 'stub.access.token',
+  refreshToken: 'stub-refresh-token',
+};
+
+export const stubCompletedEntry: TimeEntry = {
+  id: '33333333-3333-4333-8333-333333333333',
+  userId: stubUser.id,
+  startTime: '2026-01-05T09:00:00Z',
+  endTime: '2026-01-05T11:30:00Z',
+  status: 'completed',
+  note: 'Analytical engine design',
+  createdAt: '2026-01-05T09:00:00Z',
+  updatedAt: '2026-01-05T11:30:00Z',
+};
+
+export const stubRunningEntry: TimeEntry = {
+  id: '44444444-4444-4444-8444-444444444444',
+  userId: stubUser.id,
+  startTime: '2026-01-05T13:00:00Z',
+  endTime: null,
+  status: 'running',
+  note: null,
+  createdAt: '2026-01-05T13:00:00Z',
+  updatedAt: '2026-01-05T13:00:00Z',
+};
+
+export const stubTeam: Team = {
+  id: '55555555-5555-4555-8555-555555555555',
+  name: 'Engineering',
+  adminIds: [stubUser.id],
+  memberIds: [stubUser.id, '22222222-2222-4222-8222-222222222222'],
+  createdAt: '2026-01-05T08:00:00Z',
+  updatedAt: '2026-01-05T08:00:00Z',
+};
+
+export const stubHoursReportDay: HoursReportDay = {
+  date: '2026-01-05',
+  totalMinutes: 150, // matches stubCompletedEntry: 09:00 → 11:30
+  entries: [stubCompletedEntry],
+};

--- a/libs/api/tsconfig.lib.json
+++ b/libs/api/tsconfig.lib.json
@@ -12,7 +12,11 @@
     "types": ["node"]
   },
   "include": ["src/**/*.ts"],
-  "references": [],
+  "references": [
+    {
+      "path": "../core"
+    }
+  ],
   "exclude": [
     "vite.config.ts",
     "vite.config.mts",

--- a/libs/core/README.md
+++ b/libs/core/README.md
@@ -2,6 +2,11 @@
 
 Domain models and TypeScript types shared across the workspace.
 
+`src/models` holds the domain entities and their Zod validators, `src/repositories` the
+persistence interfaces, and `src/contract` the request and response shapes that cross the HTTP
+boundary in [`openapi.yaml`](../api/openapi.yaml) — types only, so consumers of the contract do
+not depend on the API package.
+
 ## Building
 
 ```bash
@@ -14,4 +19,4 @@ bun run --filter @schediochron/core build
 bun run --filter @schediochron/core test
 ```
 
-Tests run on [Vitest](https://vitest.dev/).
+Tests run on [`bun test`](https://bun.com/docs/cli/test).

--- a/libs/core/src/contract/auth.ts
+++ b/libs/core/src/contract/auth.ts
@@ -1,0 +1,31 @@
+import type { User } from '../models/user.js';
+
+export interface TokenPair {
+  accessToken: string; // short-lived signed JWT
+  refreshToken: string; // long-lived opaque token
+}
+
+/** Successful authentication — the user plus a fresh token pair. */
+export interface AuthResponse extends TokenPair {
+  user: User;
+}
+
+export interface RegisterRequest {
+  username: string; // 3–50 chars, [a-zA-Z0-9_-]
+  password: string; // min 8 chars
+  displayName?: string; // 1–100 chars
+  email?: string;
+}
+
+export interface LoginRequest {
+  username: string;
+  password: string;
+}
+
+export interface RefreshRequest {
+  refreshToken: string;
+}
+
+export interface LogoutRequest {
+  refreshToken: string;
+}

--- a/libs/core/src/contract/error.ts
+++ b/libs/core/src/contract/error.ts
@@ -1,0 +1,7 @@
+/**
+ * Standard error envelope used for all 4xx and 5xx responses.
+ */
+export interface ErrorResponse {
+  error: string; // human-readable message
+  details?: unknown; // optional structured detail, e.g. field-level errors
+}

--- a/libs/core/src/contract/report.ts
+++ b/libs/core/src/contract/report.ts
@@ -1,0 +1,19 @@
+import type { TimeEntry } from '../models/time-entry.js';
+
+/** Pre-set reporting window, shorthand for an explicit `from`/`to` pair. */
+export type HoursReportRange = 'day' | 'week' | 'month';
+
+/** Per-day summary in the hours report. */
+export interface HoursReportDay {
+  date: string; // ISO 8601 date, e.g. "2026-03-26"
+  totalMinutes: number; // sum over the day's completed entries
+  entries: TimeEntry[]; // completed entries falling on this date
+}
+
+/** Query parameters for `GET /reports/hours`. */
+export interface HoursReportQuery {
+  userId?: string; // defaults to the authenticated user; admins may pass any
+  range?: HoursReportRange;
+  from?: string; // ISO 8601 date; overrides `range`
+  to?: string; // ISO 8601 date; overrides `range`
+}

--- a/libs/core/src/contract/team.ts
+++ b/libs/core/src/contract/team.ts
@@ -1,0 +1,11 @@
+export interface CreateTeamRequest {
+  name: string; // 1–255 chars
+}
+
+export interface UpdateTeamRequest {
+  name: string; // 1–255 chars
+}
+
+export interface AddTeamMemberRequest {
+  userId: string; // UUID v4
+}

--- a/libs/core/src/contract/time-entry.ts
+++ b/libs/core/src/contract/time-entry.ts
@@ -1,0 +1,29 @@
+import type { TimeEntryStatus } from '../models/time-entry.js';
+
+/** Creates a completed (manual) entry — both ends are required. */
+export interface CreateTimeEntryRequest {
+  startTime: string; // ISO 8601 UTC; seconds will be zeroed
+  endTime: string; // ISO 8601 UTC; must be after startTime
+  note?: string; // max 255 chars
+}
+
+/** All fields optional; at least one must be provided. `null` clears the field. */
+export interface UpdateTimeEntryRequest {
+  startTime?: string;
+  endTime?: string | null;
+  note?: string | null;
+}
+
+export interface StartTimeEntryRequest {
+  note?: string; // max 255 chars
+}
+
+export interface StopTimeEntryRequest {
+  note?: string | null; // set or overwrite the note at clock-out
+}
+
+/** Query parameters for `GET /time-entries`. */
+export interface ListTimeEntriesQuery {
+  userId?: string; // admin only
+  status?: TimeEntryStatus;
+}

--- a/libs/core/src/contract/user.ts
+++ b/libs/core/src/contract/user.ts
@@ -1,0 +1,12 @@
+import type { UserRole } from '../models/user.js';
+
+/** All fields optional; at least one must be provided. `null` clears the field. */
+export interface UpdateUserRequest {
+  displayName?: string | null; // max 100 chars
+  email?: string | null;
+  role?: UserRole; // admin only
+}
+
+export interface AdminPasswordResetRequest {
+  newPassword: string; // min 8 chars
+}

--- a/libs/core/src/index.ts
+++ b/libs/core/src/index.ts
@@ -13,3 +13,36 @@ export type { UserRepository } from './repositories/user-repository.js';
 export type { TeamRepository } from './repositories/team-repository.js';
 
 export { computeDuration } from './utils/time-entry.js';
+
+// Wire contract — the shapes crossing the HTTP boundary (openapi.yaml).
+// Types only: request validation lives in the API layer (#71).
+export type { ErrorResponse } from './contract/error.js';
+export type {
+  TokenPair,
+  AuthResponse,
+  RegisterRequest,
+  LoginRequest,
+  RefreshRequest,
+  LogoutRequest,
+} from './contract/auth.js';
+export type {
+  UpdateUserRequest,
+  AdminPasswordResetRequest,
+} from './contract/user.js';
+export type {
+  CreateTimeEntryRequest,
+  UpdateTimeEntryRequest,
+  StartTimeEntryRequest,
+  StopTimeEntryRequest,
+  ListTimeEntriesQuery,
+} from './contract/time-entry.js';
+export type {
+  CreateTeamRequest,
+  UpdateTeamRequest,
+  AddTeamMemberRequest,
+} from './contract/team.js';
+export type {
+  HoursReportRange,
+  HoursReportDay,
+  HoursReportQuery,
+} from './contract/report.js';


### PR DESCRIPTION
Closes #83.

Routes every operation in `libs/api/openapi.yaml` — all 23 of them — to a stub handler, so the contract is proven implementable and the API shape is fixed before Phase 2 wires in real logic.

## Where the wire types live

The contract needs shapes `core` didn't have: `TokenPair`, `AuthResponse`, `HoursReportDay`, `ErrorResponse` and the request bodies. These now live in `libs/core/src/contract` alongside the domain models, as **types only** — no Zod, since validation is deferred to #71.

The alternative was keeping them local to `libs/api`, but then `react-app` would have to depend on the *server* package just to type its calls. Putting them in `core` keeps the dependency tree pointing one way:

```
api       ──depends──▶ core
react-app ──depends──▶ core
```

## Shape of the change

- `src/routes/` — one module per resource group, mirroring the tags in the contract.
- `src/stub-data.ts` — fixed sample payloads. Constant, not generated, so responses are deterministic.
- `app.ts` — mounts the groups and returns the contract's `ErrorResponse` envelope for unrouted paths and uncaught throws, rather than Hono's plain-text defaults.
- Path ids are echoed into responses (`GET /teams/abc` → `{"id":"abc",…}`) so a stub reflects the route it was reached through.

## Testing

71 tests in the package, on two levels:

- **A table of all 23 operations** in `app.spec.ts` asserting method, path and success status. A route that goes missing, lands on the wrong path, or binds the wrong method fails here.
- **Per-resource shape specs** that push each payload through `core`'s own `validateUser` / `validateTimeEntry` / `validateTeam`, so a stub that violates a domain invariant fails the build. The report spec additionally checks `totalMinutes` against `computeDuration` over the entries it lists.

I mutation-checked the suite (unmounting `/reports` — 4 tests failed as they should) and verified the endpoints over real HTTP against a running server, not just in-process `app.request`.

I also dropped a "routing precedence" test I'd written for `/time-entries/start` vs `/:id`: `/:id` is only ever GET/PATCH/DELETE and `/start` is POST-only, so the two can never compete and the test would have passed regardless of the behaviour it claimed to check.

## Docs

Both `libs/core/README.md` and `libs/api/README.md` claimed *"Tests run on Vitest"* — removed in #120. Corrected to `bun test`, and the roadmap's "serving a health check" line is now accurate.

## Not in scope

Auth, authorisation and request validation are absent by design — every endpoint answers as though the caller were authorised (#71 covers this in Phase 2).

Noticed but left alone: four `tsconfig.*.json` files still exclude `vite.config.*` / `vitest.config.*` paths that can no longer exist. Dead but harmless — happy to sweep it in a separate chore.

🤖 Generated with [Claude Code](https://claude.com/claude-code)