### PR TITLE
feature(126) + [core] expand the repository interfaces

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@
 dist
 tmp
 out-tsc
+*.tsbuildinfo
 
 # dependencies
 node_modules

--- a/libs/core/src/index.ts
+++ b/libs/core/src/index.ts
@@ -8,9 +8,18 @@ export { userSchema, validateUser } from './models/user.js';
 export type { Team } from './models/team.js';
 export { teamSchema, validateTeam } from './models/team.js';
 
+export type { RefreshToken } from './models/refresh-token.js';
+export {
+  refreshTokenSchema,
+  validateRefreshToken,
+  isRefreshTokenActive,
+} from './models/refresh-token.js';
+
+export type { CrudRepository } from './repositories/crud-repository.js';
 export type { TimeEntryRepository } from './repositories/time-entry-repository.js';
 export type { UserRepository } from './repositories/user-repository.js';
 export type { TeamRepository } from './repositories/team-repository.js';
+export type { RefreshTokenRepository } from './repositories/refresh-token-repository.js';
 
 export { computeDuration } from './utils/time-entry.js';
 

--- a/libs/core/src/models/refresh-token.spec.ts
+++ b/libs/core/src/models/refresh-token.spec.ts
@@ -1,0 +1,106 @@
+import { describe, it, expect } from 'bun:test';
+import { validateRefreshToken, isRefreshTokenActive } from './refresh-token.js';
+
+const validToken = {
+  token: 'e8b7c1a0f4d24e9b8a1c3f5d7e9b0a2c',
+  userId: '123e4567-e89b-12d3-a456-426614174000',
+  expiresAt: '2024-01-08T10:00:00Z',
+  revokedAt: null,
+};
+
+describe('validateRefreshToken', () => {
+  describe('valid tokens', () => {
+    it('accepts a live token', () => {
+      const result = validateRefreshToken(validToken);
+      expect(result.success).toBe(true);
+    });
+
+    it('accepts a revoked token', () => {
+      const result = validateRefreshToken({
+        ...validToken,
+        revokedAt: '2024-01-02T10:00:00Z',
+      });
+      expect(result.success).toBe(true);
+    });
+  });
+
+  describe('token validation', () => {
+    it('rejects an empty token', () => {
+      const result = validateRefreshToken({ ...validToken, token: '' });
+      expect(result.success).toBe(false);
+    });
+  });
+
+  describe('userId validation', () => {
+    it('rejects invalid UUID', () => {
+      const result = validateRefreshToken({ ...validToken, userId: 'nope' });
+      expect(result.success).toBe(false);
+    });
+  });
+
+  describe('timestamp validation', () => {
+    it('rejects non-ISO expiresAt', () => {
+      const result = validateRefreshToken({
+        ...validToken,
+        expiresAt: '08/01/2024',
+      });
+      expect(result.success).toBe(false);
+    });
+
+    it('rejects non-ISO revokedAt', () => {
+      const result = validateRefreshToken({
+        ...validToken,
+        revokedAt: 'yesterday',
+      });
+      expect(result.success).toBe(false);
+    });
+  });
+});
+
+describe('isRefreshTokenActive', () => {
+  const now = new Date('2024-01-01T10:00:00Z');
+
+  it('accepts a token that is unrevoked and unexpired', () => {
+    expect(isRefreshTokenActive(validToken, now)).toBe(true);
+  });
+
+  it('rejects a token past its expiry', () => {
+    expect(
+      isRefreshTokenActive(
+        { ...validToken, expiresAt: '2023-12-31T10:00:00Z' },
+        now,
+      ),
+    ).toBe(false);
+  });
+
+  it('rejects a token expiring exactly now', () => {
+    expect(
+      isRefreshTokenActive(
+        { ...validToken, expiresAt: '2024-01-01T10:00:00Z' },
+        now,
+      ),
+    ).toBe(false);
+  });
+
+  it('rejects a revoked token that has not yet expired', () => {
+    expect(
+      isRefreshTokenActive(
+        { ...validToken, revokedAt: '2023-12-31T10:00:00Z' },
+        now,
+      ),
+    ).toBe(false);
+  });
+
+  it('rejects a token that is both revoked and expired', () => {
+    expect(
+      isRefreshTokenActive(
+        {
+          ...validToken,
+          expiresAt: '2023-12-30T10:00:00Z',
+          revokedAt: '2023-12-31T10:00:00Z',
+        },
+        now,
+      ),
+    ).toBe(false);
+  });
+});

--- a/libs/core/src/models/refresh-token.ts
+++ b/libs/core/src/models/refresh-token.ts
@@ -1,0 +1,42 @@
+import { z } from 'zod';
+
+/**
+ * An issued refresh token, persisted so it can be revoked.
+ *
+ * Unlike access tokens, which are stateless signed JWTs, refresh tokens are
+ * opaque — validity is decided by lookup, not by signature, so this record is
+ * the source of truth for whether the token still works.
+ */
+export interface RefreshToken {
+  token: string; // opaque; unique system-wide; the lookup key
+  userId: string; // UUID v4; the user the token authenticates
+  expiresAt: string; // ISO 8601 UTC
+  revokedAt: string | null; // ISO 8601 UTC; null while the token is live
+}
+
+export const refreshTokenSchema = z.object({
+  token: z.string().min(1, 'Refresh token must not be empty'),
+  userId: z.string().uuid(),
+  expiresAt: z.string().datetime({ offset: false }),
+  revokedAt: z.string().datetime({ offset: false }).nullable(),
+});
+
+export function validateRefreshToken(
+  data: unknown,
+): z.SafeParseReturnType<RefreshToken, RefreshToken> {
+  return refreshTokenSchema.safeParse(data) as z.SafeParseReturnType<
+    RefreshToken,
+    RefreshToken
+  >;
+}
+
+/** A token is usable only while neither revoked nor expired. */
+export function isRefreshTokenActive(
+  token: RefreshToken,
+  now: Date = new Date(),
+): boolean {
+  if (token.revokedAt !== null) {
+    return false;
+  }
+  return new Date(token.expiresAt).getTime() > now.getTime();
+}

--- a/libs/core/src/repositories/crud-repository.ts
+++ b/libs/core/src/repositories/crud-repository.ts
@@ -1,0 +1,20 @@
+/**
+ * The CRUD surface every entity repository shares. Scoped and filtered lookups
+ * belong on the specific repositories.
+ */
+export interface CrudRepository<T> {
+  /** `null` when no entity carries that id — absence is not an error. */
+  findById(id: string): Promise<T | null>;
+
+  /** Every entity, unscoped. */
+  findAll(): Promise<T[]>;
+
+  /** Returns the entity as stored; `createdAt`/`updatedAt` are set on write. */
+  create(item: T): Promise<T>;
+
+  /** Returns the entity as stored; refreshes `updatedAt`. */
+  update(item: T): Promise<T>;
+
+  /** Deleting an unknown id is a no-op. */
+  delete(id: string): Promise<void>;
+}

--- a/libs/core/src/repositories/refresh-token-repository.ts
+++ b/libs/core/src/repositories/refresh-token-repository.ts
@@ -1,0 +1,26 @@
+import type { RefreshToken } from '../models/refresh-token.js';
+
+/**
+ * Server-side refresh token storage — the record that makes a token revocable.
+ * Where it lives (memory, SQL, Redis) is the adapter's choice.
+ *
+ * Not a `CrudRepository`: tokens are addressed by their opaque value rather
+ * than an id, are never updated in place (rotation mints a new token and
+ * revokes the old), and are never listed in bulk.
+ */
+export interface RefreshTokenRepository {
+  /** Persists a newly minted token. */
+  create(token: RefreshToken): Promise<RefreshToken>;
+
+  /**
+   * Looks up by opaque value — the only handle a client holds. `null` when
+   * never issued; a found token still needs its expiry and revocation checked.
+   */
+  findByToken(token: string): Promise<RefreshToken | null>;
+
+  /** Revoking an unknown or already-revoked token is a no-op. */
+  revoke(token: string): Promise<void>;
+
+  /** Revokes every token for the user, live or not. */
+  revokeAllForUser(userId: string): Promise<void>;
+}

--- a/libs/core/src/repositories/repositories.spec.ts
+++ b/libs/core/src/repositories/repositories.spec.ts
@@ -1,0 +1,132 @@
+import { describe, it, expect } from 'bun:test';
+import type { Team } from '../models/team.js';
+import type { TimeEntry } from '../models/time-entry.js';
+import type { User } from '../models/user.js';
+import type { RefreshToken } from '../models/refresh-token.js';
+import type { CrudRepository } from './crud-repository.js';
+import type { TeamRepository } from './team-repository.js';
+import type { TimeEntryRepository } from './time-entry-repository.js';
+import type { UserRepository } from './user-repository.js';
+import type { RefreshTokenRepository } from './refresh-token-repository.js';
+
+/**
+ * These interfaces have no runtime, so the assertions that matter here are the
+ * type annotations, checked by `tsc -b`, not the `expect` calls. The stubs
+ * below are conformance fixtures: they compile only while each interface stays
+ * implementable and substitutable for its base. Real behaviour is the
+ * adapters' to test.
+ */
+
+const timeEntryRepository: TimeEntryRepository = {
+  findById: async () => null,
+  findAll: async () => [],
+  create: async (item) => item,
+  update: async (item) => item,
+  delete: async () => {},
+  findRunning: async () => null,
+  find: async () => [],
+};
+
+const userRepository: UserRepository = {
+  findById: async () => null,
+  findAll: async () => [],
+  create: async (item) => item,
+  update: async (item) => item,
+  delete: async () => {},
+  findByUsername: async () => null,
+};
+
+const team: Team = {
+  id: '123e4567-e89b-12d3-a456-426614174000',
+  name: 'Engineering',
+  adminIds: ['123e4567-e89b-12d3-a456-426614174001'],
+  memberIds: ['123e4567-e89b-12d3-a456-426614174001'],
+  createdAt: '2024-01-01T10:00:00Z',
+  updatedAt: '2024-01-01T10:00:00Z',
+};
+
+const teamRepository: TeamRepository = {
+  findById: async () => null,
+  findAll: async () => [],
+  create: async (item) => item,
+  update: async (item) => item,
+  delete: async () => {},
+  findByUserId: async () => [],
+  addMember: async () => team,
+  removeMember: async () => team,
+  assignAdmin: async () => team,
+  removeAdmin: async () => team,
+};
+
+const refreshTokenRepository: RefreshTokenRepository = {
+  create: async (token) => token,
+  findByToken: async () => null,
+  revoke: async () => {},
+  revokeAllForUser: async () => {},
+};
+
+describe('repository interfaces', () => {
+  describe('substitutability', () => {
+    it('TimeEntryRepository stands in for CrudRepository<TimeEntry>', () => {
+      const base: CrudRepository<TimeEntry> = timeEntryRepository;
+      expect(base.findAll).toBeDefined();
+    });
+
+    it('UserRepository stands in for CrudRepository<User>', () => {
+      const base: CrudRepository<User> = userRepository;
+      expect(base.findAll).toBeDefined();
+    });
+
+    it('TeamRepository stands in for CrudRepository<Team>', () => {
+      const base: CrudRepository<Team> = teamRepository;
+      expect(base.findAll).toBeDefined();
+    });
+
+    it('findAll takes no arguments on any repository', async () => {
+      // A subtype adding a required parameter here would not compile.
+      await expect(timeEntryRepository.findAll()).resolves.toEqual([]);
+      await expect(userRepository.findAll()).resolves.toEqual([]);
+      await expect(teamRepository.findAll()).resolves.toEqual([]);
+    });
+  });
+
+  describe('absence is representable', () => {
+    it('findRunning may answer null', async () => {
+      const running: TimeEntry | null =
+        await timeEntryRepository.findRunning('user-id');
+      expect(running).toBeNull();
+    });
+
+    it('findByUsername may answer null', async () => {
+      const user: User | null = await userRepository.findByUsername('nobody');
+      expect(user).toBeNull();
+    });
+
+    it('findByToken may answer null', async () => {
+      const token: RefreshToken | null =
+        await refreshTokenRepository.findByToken('unknown');
+      expect(token).toBeNull();
+    });
+  });
+
+  describe('TimeEntryRepository.find', () => {
+    it('accepts an empty filter', async () => {
+      await expect(timeEntryRepository.find({})).resolves.toEqual([]);
+    });
+
+    it('accepts each criterion independently', async () => {
+      await expect(
+        timeEntryRepository.find({ userId: 'user-id' }),
+      ).resolves.toEqual([]);
+      await expect(
+        timeEntryRepository.find({ status: 'running' }),
+      ).resolves.toEqual([]);
+      await expect(
+        timeEntryRepository.find({
+          from: '2024-01-01T00:00:00Z',
+          to: '2024-01-31T23:59:00Z',
+        }),
+      ).resolves.toEqual([]);
+    });
+  });
+});

--- a/libs/core/src/repositories/team-repository.ts
+++ b/libs/core/src/repositories/team-repository.ts
@@ -1,9 +1,29 @@
 import type { Team } from '../models/team.js';
+import type { CrudRepository } from './crud-repository.js';
 
-export interface TeamRepository {
-  findById(id: string): Promise<Team | null>;
-  findAll(): Promise<Team[]>;
-  create(team: Team): Promise<Team>;
-  update(team: Team): Promise<Team>;
-  delete(id: string): Promise<void>;
+/**
+ * Teams and their membership.
+ *
+ * The membership mutations are separate operations rather than `update(team)`
+ * calls because each must hold `adminIds ⊆ memberIds` and `adminIds` non-empty
+ * atomically — a read-modify-write cannot.
+ */
+export interface TeamRepository extends CrudRepository<Team> {
+  /** Teams the user participates in, by `memberIds`. Empty is normal. */
+  findByUserId(userId: string): Promise<Team[]>;
+
+  /** Adds to `memberIds` without admin rights. Already a member is a no-op. */
+  addMember(teamId: string, userId: string): Promise<Team>;
+
+  /**
+   * Removes from `memberIds` and, if present, `adminIds`.
+   * Rejects removing the last admin.
+   */
+  removeMember(teamId: string, userId: string): Promise<Team>;
+
+  /** Adds to `adminIds`, and to `memberIds` if absent. Both or neither. */
+  assignAdmin(teamId: string, userId: string): Promise<Team>;
+
+  /** Removes from `adminIds`, leaving membership. Rejects the last admin. */
+  removeAdmin(teamId: string, userId: string): Promise<Team>;
 }

--- a/libs/core/src/repositories/time-entry-repository.ts
+++ b/libs/core/src/repositories/time-entry-repository.ts
@@ -1,9 +1,23 @@
-import type { TimeEntry } from '../models/time-entry.js';
+import type { TimeEntry, TimeEntryStatus } from '../models/time-entry.js';
+import type { CrudRepository } from './crud-repository.js';
 
-export interface TimeEntryRepository {
-  findById(id: string): Promise<TimeEntry | null>;
-  findAll(userId: string): Promise<TimeEntry[]>;
-  create(entry: TimeEntry): Promise<TimeEntry>;
-  update(entry: TimeEntry): Promise<TimeEntry>;
-  delete(id: string): Promise<void>;
+export interface TimeEntryRepository extends CrudRepository<TimeEntry> {
+  /**
+   * The user's open entry, or `null` when they are clocked out.
+   *
+   * Returns at most one: a user has at most one running entry, and this is
+   * where that invariant is enforced on clock-in.
+   */
+  findRunning(userId: string): Promise<TimeEntry | null>;
+
+  /**
+   * Entries matching every criterion given; omitted criteria don't constrain.
+   * `from`/`to` bound `startTime` inclusively.
+   */
+  find(filter: {
+    userId?: string;
+    status?: TimeEntryStatus;
+    from?: string;
+    to?: string;
+  }): Promise<TimeEntry[]>;
 }

--- a/libs/core/src/repositories/user-repository.ts
+++ b/libs/core/src/repositories/user-repository.ts
@@ -1,9 +1,9 @@
 import type { User } from '../models/user.js';
+import type { CrudRepository } from './crud-repository.js';
 
-export interface UserRepository {
-  findById(id: string): Promise<User | null>;
-  findAll(): Promise<User[]>;
-  create(user: User): Promise<User>;
-  update(user: User): Promise<User>;
-  delete(id: string): Promise<void>;
+export interface UserRepository extends CrudRepository<User> {
+  /**
+   * Finds a user by username (unique). Useful for Auth.
+   */
+  findByUsername(username: string): Promise<User | null>;
 }


### PR DESCRIPTION
Closes #126.

Grows the `@schediochron/core` repository interfaces to cover the queries the API
actually needs, so #26, #27 and #28 have a contract to implement against.

## Interfaces

The five CRUD methods common to every entity move into `CrudRepository<T>`.
`findAll()` takes no argument: only time entries ever scoped it, and a subtype
cannot add a required parameter without breaking substitutability. Scoped and
filtered lookups therefore live on the specific repositories.

- **`TimeEntryRepository`** — `findRunning(userId)` returns `null` when the user
  is clocked out, since being clocked out is the normal state. `find(filter)`
  covers the contract's `userId`/`status` listing and the report's date window in
  one query, rather than positional `from`/`to` that swap silently.
- **`UserRepository`** — `findByUsername(username)` returns at most one user,
  matching the system-wide uniqueness of `username`.
- **`TeamRepository`** — `findByUserId(userId)` for the teams a user belongs to,
  plus `addMember` / `removeMember` / `assignAdmin` / `removeAdmin`. These are
  discrete operations rather than `update(team)` calls because the admin-subset
  and at-least-one-admin invariants must hold atomically: two concurrent removals
  can each read a team with two admins and each write back a team with one.
- **`RefreshTokenRepository`** — new, alongside a `RefreshToken` model.
  Refresh tokens are revocable, which needs a server-side record, but this fixes
  the contract without fixing the storage — memory, SQL or Redis are all adapters
  behind it. `revokeAllForUser` serves the password reset side effect.

Interfaces stay persistence-agnostic, and each query documents the invariant it
exists to serve.

## Tests

`RefreshToken` has unit tests for validation and for `isRefreshTokenActive`
(expiry boundary, revoked-but-unexpired).

The interfaces have no runtime, so `repositories.spec.ts` holds conformance
fixtures whose real assertions are the type annotations, checked by `tsc -b`.
Both regressions they guard against were verified by hand: re-narrowing
`findRunning` to `Promise<TimeEntry>` and restoring a required parameter on
`findAll` each fail the build.

Typecheck, lint, format and 69 tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)