### PR TITLE
feature(25) + [sql] define database schema and migrations

### DIFF
--- a/libs/sql/README.md
+++ b/libs/sql/README.md
@@ -9,11 +9,42 @@ This package uses Bun's built-in [`Bun.sql`](https://bun.sh/docs/api/sql)
 PostgreSQL client — no external driver dependency. This mirrors the Bun-native
 stance elsewhere in the stack (e.g. `Bun.password` for hashing in the API).
 
+## Schema and migrations
+
+The MVP schema lives in [`migrations/`](./migrations) as plain-SQL up/down pairs
+named `<version>_<name>.up.sql` / `.down.sql`. Every table expresses a model in
+`@schediochron/core` and the invariants its ADR fixes — see the comments in
+[`0001_initial_schema.up.sql`](./migrations/0001_initial_schema.up.sql):
+
+- `users`, `teams`, `team_members` (the join table behind the two-array Team
+  model — `is_admin` marks admins, making `adminIds ⊆ memberIds` structural),
+  `time_entries`, `refresh_tokens`.
+- Password hashes live in a separate `user_credentials` table, **not** a `users`
+  column: the `User` model and `UserRepository` are credential-free by design
+  (ADR-002), so the hash is owned by the auth layer and never flows through the
+  repository.
+- One-running-entry-per-user (ADR-001) is enforced by a **partial unique index**
+  on `time_entries (user_id) WHERE status = 'running'`, so a second clock-in
+  fails at the database, not only in application code.
+- No `duration` or `date` columns on `time_entries` — both are derived.
+
+A dependency-free runner (`src/migrate.ts`) tracks applied versions in a
+`schema_migrations` table and applies each migration in its own transaction.
+
+```bash
+export DATABASE_URL=postgres://user:pass@localhost:5432/schediochron
+bun run --filter @schediochron/sql migrate          # apply pending (up)
+bun run --filter @schediochron/sql migrate status    # list applied/pending
+bun run --filter @schediochron/sql migrate down [n]  # revert the last n (default 1)
+```
+
+`DATABASE_URL` has no default — a missing value is a configuration error. A local
+PostgreSQL to run these against is provided by the Docker Compose setup (#36).
+
 ## Status
 
-Scaffolding. The following land on top of this layout:
+Scaffolding beyond the schema. Still to land on top of this layout:
 
-- Schema and migrations (#25)
 - `TimeEntry`, `User` and `Team` repositories (#26, #27, #28)
 - Development seed data (#72)
 
@@ -21,3 +52,4 @@ Scaffolding. The following land on top of this layout:
 
 - `bun run --filter @schediochron/sql build` — type-check and emit to `dist/`
 - `bun run --filter @schediochron/sql test` — run the test suite
+- `bun run --filter @schediochron/sql migrate` — apply migrations (see above)

--- a/libs/sql/migrations/0001_initial_schema.down.sql
+++ b/libs/sql/migrations/0001_initial_schema.down.sql
@@ -1,0 +1,8 @@
+-- Reverses 0001_initial_schema.up.sql. Dropped in reverse dependency order;
+-- CASCADE also removes the indexes and constraints created above.
+DROP TABLE IF EXISTS refresh_tokens;
+DROP TABLE IF EXISTS time_entries;
+DROP TABLE IF EXISTS team_members;
+DROP TABLE IF EXISTS teams;
+DROP TABLE IF EXISTS user_credentials;
+DROP TABLE IF EXISTS users;

--- a/libs/sql/migrations/0001_initial_schema.up.sql
+++ b/libs/sql/migrations/0001_initial_schema.up.sql
@@ -1,0 +1,115 @@
+-- 0001 initial schema
+--
+-- The MVP schema for Schediochron. Every table and constraint here expresses a
+-- model in @schediochron/core and the invariants its ADR fixes; deviations are
+-- called out inline. Column names follow the models (snake_case at the wall).
+
+-- Users — ADR-002 / models/user.ts.
+CREATE TABLE users (
+  id            uuid        PRIMARY KEY DEFAULT gen_random_uuid(),
+  username      text        NOT NULL UNIQUE,
+  display_name  text,
+  email         text        UNIQUE, -- unique-when-present: Postgres allows many NULLs
+  role          text        NOT NULL CHECK (role IN ('admin', 'member')),
+  created_at    timestamptz NOT NULL DEFAULT now(),
+  updated_at    timestamptz NOT NULL DEFAULT now(),
+  CONSTRAINT users_username_format
+    CHECK (char_length(username) BETWEEN 3 AND 50 AND username ~ '^[A-Za-z0-9_-]+$'),
+  CONSTRAINT users_display_name_len
+    CHECK (display_name IS NULL OR char_length(display_name) BETWEEN 1 AND 100),
+  CONSTRAINT users_email_nonempty
+    CHECK (email IS NULL OR char_length(email) >= 1)
+);
+
+-- Password credentials — deliberately a separate table, not a `users` column.
+--
+-- The User model and UserRepository (#126) are credential-free by design: ADR-002
+-- fixes `passwordHash` as living "only in the persistence layer", never exposed,
+-- and never a field on `User`. Putting the hash on `users` would make
+-- `UserRepository.create(user: User)` unable to satisfy a NOT NULL column, since
+-- nothing in `User` carries it. Splitting it out keeps UserRepository pure and
+-- the hash NOT NULL where it is stored.
+--
+-- The auth layer (#29/#30) owns this table; UserRepository never touches it. A
+-- user row may exist before its credential is written; registration writes both
+-- in one transaction, and a user without a credential simply cannot authenticate.
+CREATE TABLE user_credentials (
+  user_id       uuid        PRIMARY KEY REFERENCES users (id) ON DELETE CASCADE,
+  password_hash text        NOT NULL,
+  updated_at    timestamptz NOT NULL DEFAULT now()
+);
+
+-- Teams — ADR-004 / models/team.ts.
+CREATE TABLE teams (
+  id         uuid        PRIMARY KEY DEFAULT gen_random_uuid(),
+  name       text        NOT NULL CHECK (char_length(btrim(name)) BETWEEN 1 AND 255),
+  created_at timestamptz NOT NULL DEFAULT now(),
+  updated_at timestamptz NOT NULL DEFAULT now()
+);
+
+-- Team membership — the join table behind the two-array Team model.
+--
+-- A row is a membership; is_admin marks the admins among the members. This is
+-- what makes `adminIds ⊆ memberIds` (ADR-004) structural rather than checked:
+-- an admin *is* a member row, so it cannot be an admin without being a member.
+-- `memberIds` = every row for the team; `adminIds` = rows where is_admin.
+--
+-- "At least one admin" (ADR-004) cannot be expressed as a row constraint and is
+-- enforced by the Team repository (#28) inside the membership mutations.
+CREATE TABLE team_members (
+  team_id    uuid        NOT NULL REFERENCES teams (id) ON DELETE CASCADE,
+  user_id    uuid        NOT NULL REFERENCES users (id) ON DELETE CASCADE,
+  is_admin   boolean     NOT NULL DEFAULT false,
+  created_at timestamptz NOT NULL DEFAULT now(),
+  PRIMARY KEY (team_id, user_id)
+);
+
+-- Teams a user participates in — TeamRepository.findByUserId.
+CREATE INDEX team_members_user_id ON team_members (user_id);
+
+-- Time entries — ADR-001 / models/time-entry.ts.
+--
+-- No `duration` column: duration is computed on demand (core computeDuration).
+-- No `date` column: the day is derived from start_time.
+CREATE TABLE time_entries (
+  id         uuid        PRIMARY KEY DEFAULT gen_random_uuid(),
+  user_id    uuid        NOT NULL REFERENCES users (id) ON DELETE CASCADE,
+  start_time timestamptz NOT NULL,
+  end_time   timestamptz, -- null while running
+  status     text        NOT NULL CHECK (status IN ('running', 'completed')),
+  note       text        CHECK (note IS NULL OR char_length(note) BETWEEN 1 AND 255),
+  created_at timestamptz NOT NULL DEFAULT now(),
+  updated_at timestamptz NOT NULL DEFAULT now(),
+  -- Invariant 1 (ADR-001): running ↔ end_time null, completed ↔ end_time set.
+  CONSTRAINT time_entries_status_end_time CHECK (
+    (status = 'running'   AND end_time IS NULL) OR
+    (status = 'completed' AND end_time IS NOT NULL)
+  ),
+  -- Invariant 2 (ADR-001): a completed interval is non-empty, start < end.
+  CONSTRAINT time_entries_interval CHECK (end_time IS NULL OR end_time > start_time)
+);
+
+-- One running entry per user (ADR-001). The database is the enforcement point:
+-- a second clock-in raises a unique violation the repository maps to a 409.
+CREATE UNIQUE INDEX time_entries_one_running_per_user
+  ON time_entries (user_id) WHERE status = 'running';
+
+-- Range and per-user lookups — TimeEntryRepository.find (from/to bound start_time).
+CREATE INDEX time_entries_user_start ON time_entries (user_id, start_time);
+
+-- Refresh tokens — ADR-003 / models/refresh-token.ts.
+--
+-- `token` holds the *hash* of the opaque token the client carries (#25 stores
+-- hashed; the repository hashes on write and on lookup). It is the lookup key,
+-- so it is the primary key. revoked_at null means live; logout and admin
+-- password reset set it, and refresh answers 401 for a revoked or expired row.
+CREATE TABLE refresh_tokens (
+  token      text        PRIMARY KEY,
+  user_id    uuid        NOT NULL REFERENCES users (id) ON DELETE CASCADE,
+  expires_at timestamptz NOT NULL,
+  revoked_at timestamptz,
+  created_at timestamptz NOT NULL DEFAULT now()
+);
+
+-- Revoke-all-for-user — RefreshTokenRepository.revokeAllForUser.
+CREATE INDEX refresh_tokens_user_id ON refresh_tokens (user_id);

--- a/libs/sql/package.json
+++ b/libs/sql/package.json
@@ -18,13 +18,15 @@
   "files": [
     "dist",
     "src",
+    "migrations",
     "!**/*.spec.*",
     "!**/*.tsbuildinfo"
   ],
   "scripts": {
     "build": "tsc -b tsconfig.lib.json",
     "test": "bun test",
-    "test:watch": "bun test --watch"
+    "test:watch": "bun test --watch",
+    "migrate": "bun run src/migrate.ts"
   },
   "dependencies": {
     "@schediochron/core": "workspace:^",

--- a/libs/sql/src/db.ts
+++ b/libs/sql/src/db.ts
@@ -1,0 +1,20 @@
+import { SQL } from 'bun';
+
+/**
+ * Opens a PostgreSQL connection using Bun's native client.
+ *
+ * The connection string comes from `DATABASE_URL` unless one is passed
+ * explicitly (tests pass an ephemeral database). There is no default: a missing
+ * `DATABASE_URL` is a configuration error, not something to paper over with a
+ * localhost guess.
+ */
+export function createSqlClient(
+  connectionString: string | undefined = process.env.DATABASE_URL,
+): SQL {
+  if (!connectionString) {
+    throw new Error(
+      'DATABASE_URL is not set — @schediochron/sql needs a PostgreSQL connection string.',
+    );
+  }
+  return new SQL(connectionString);
+}

--- a/libs/sql/src/index.ts
+++ b/libs/sql/src/index.ts
@@ -1,7 +1,17 @@
 // Public API — the PostgreSQL adapter for @schediochron/core.
 //
 // This package implements the repository interfaces from @schediochron/core
-// against PostgreSQL, using Bun's native SQL client (`Bun.sql`). It is
-// scaffolding today: the schema and migrations (#25) and the repository
-// implementations (#26, #27, #28) land on top of this layout.
-export {};
+// against PostgreSQL, using Bun's native SQL client (`Bun.sql`). The repository
+// implementations (#26, #27, #28) land on top of the schema and migrations here.
+
+export { createSqlClient } from './db.js';
+
+export type { Migration, MigrationStatus } from './migrate.js';
+export {
+  discoverMigrations,
+  pendingMigrations,
+  migrationsToRevert,
+  migrateUp,
+  migrateDown,
+  migrationStatus,
+} from './migrate.js';

--- a/libs/sql/src/migrate.spec.ts
+++ b/libs/sql/src/migrate.spec.ts
@@ -1,0 +1,132 @@
+import { afterAll, describe, expect, it } from 'bun:test';
+import { mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import {
+  discoverMigrations,
+  migrationsToRevert,
+  pendingMigrations,
+  type Migration,
+} from './migrate.js';
+
+const tmpDirs: string[] = [];
+
+function fixtureDir(files: Record<string, string>): string {
+  const dir = mkdtempSync(join(tmpdir(), 'sql-migrate-'));
+  tmpDirs.push(dir);
+  for (const [name, contents] of Object.entries(files)) {
+    writeFileSync(join(dir, name), contents);
+  }
+  return dir;
+}
+
+afterAll(() => {
+  for (const dir of tmpDirs) rmSync(dir, { recursive: true, force: true });
+});
+
+const migration = (version: string, name = `m${version}`): Migration => ({
+  version,
+  name,
+  upPath: `${version}.up.sql`,
+  downPath: `${version}.down.sql`,
+});
+
+describe('discoverMigrations', () => {
+  it('reads the real migration directory in order with matching down files', () => {
+    const migrations = discoverMigrations();
+    expect(migrations.length).toBeGreaterThanOrEqual(1);
+    expect(migrations[0]).toMatchObject({
+      version: '0001',
+      name: 'initial_schema',
+    });
+    const versions = migrations.map((m) => m.version);
+    expect([...versions]).toEqual([...versions].sort());
+  });
+
+  it('orders migrations by zero-padded version, not discovery order', () => {
+    const dir = fixtureDir({
+      '0002_second.up.sql': '',
+      '0002_second.down.sql': '',
+      '0001_first.up.sql': '',
+      '0001_first.down.sql': '',
+    });
+    expect(discoverMigrations(dir).map((m) => m.version)).toEqual([
+      '0001',
+      '0002',
+    ]);
+  });
+
+  it('rejects a badly named migration file', () => {
+    const dir = fixtureDir({ 'initial.up.sql': '', 'initial.down.sql': '' });
+    expect(() => discoverMigrations(dir)).toThrow(/must be named/);
+  });
+
+  it('rejects an up migration with no matching down file', () => {
+    const dir = fixtureDir({ '0001_init.up.sql': '' });
+    expect(() => discoverMigrations(dir)).toThrow(/no matching/);
+  });
+
+  it('rejects duplicate versions', () => {
+    const dir = fixtureDir({
+      '0001_a.up.sql': '',
+      '0001_a.down.sql': '',
+      '0001_b.up.sql': '',
+      '0001_b.down.sql': '',
+    });
+    expect(() => discoverMigrations(dir)).toThrow(/Duplicate migration version/);
+  });
+});
+
+describe('pendingMigrations', () => {
+  const all = [migration('0001'), migration('0002'), migration('0003')];
+
+  it('returns every migration when none are applied', () => {
+    expect(pendingMigrations(all, new Set()).map((m) => m.version)).toEqual([
+      '0001',
+      '0002',
+      '0003',
+    ]);
+  });
+
+  it('skips applied migrations, preserving order', () => {
+    const applied = new Set(['0001', '0002']);
+    expect(pendingMigrations(all, applied).map((m) => m.version)).toEqual([
+      '0003',
+    ]);
+  });
+
+  it('returns nothing when all are applied', () => {
+    expect(pendingMigrations(all, new Set(['0001', '0002', '0003']))).toEqual(
+      [],
+    );
+  });
+});
+
+describe('migrationsToRevert', () => {
+  const all = [migration('0001'), migration('0002'), migration('0003')];
+  const applied = new Set(['0001', '0002', '0003']);
+
+  it('reverts the most recent migration newest-first by default', () => {
+    expect(migrationsToRevert(all, applied, 1).map((m) => m.version)).toEqual([
+      '0003',
+    ]);
+  });
+
+  it('reverts multiple steps newest-first', () => {
+    expect(migrationsToRevert(all, applied, 2).map((m) => m.version)).toEqual([
+      '0003',
+      '0002',
+    ]);
+  });
+
+  it('never reverts an unapplied migration', () => {
+    const partial = new Set(['0001']);
+    expect(migrationsToRevert(all, partial, 5).map((m) => m.version)).toEqual([
+      '0001',
+    ]);
+  });
+
+  it('reverts nothing for a non-positive step count', () => {
+    expect(migrationsToRevert(all, applied, 0)).toEqual([]);
+  });
+});

--- a/libs/sql/src/migrate.ts
+++ b/libs/sql/src/migrate.ts
@@ -1,0 +1,218 @@
+import { readdirSync, readFileSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import type { SQL } from 'bun';
+import { createSqlClient } from './db.js';
+
+/**
+ * A plain-SQL migration runner. Each migration is a pair of files under
+ * `migrations/`, `<version>_<name>.up.sql` and `<version>_<name>.down.sql`;
+ * applied versions are tracked in a `schema_migrations` table so `up` is
+ * idempotent and `down` reverses in the opposite order.
+ *
+ * Deliberately dependency-free: migrations stay readable SQL rather than a
+ * library's DSL, consistent with the Bun-native, zero-driver stance of the rest
+ * of the adapter.
+ */
+
+const MIGRATIONS_DIR = join(
+  dirname(fileURLToPath(import.meta.url)),
+  '..',
+  'migrations',
+);
+
+export interface Migration {
+  /** Zero-padded ordering key, e.g. `"0001"`. */
+  version: string;
+  /** Human-readable slug, e.g. `"initial_schema"`. */
+  name: string;
+  /** Absolute path to the `.up.sql` file. */
+  upPath: string;
+  /** Absolute path to the `.down.sql` file. */
+  downPath: string;
+}
+
+const UP_SUFFIX = '.up.sql';
+
+/**
+ * Reads the migration directory into an ordered list, validating that every
+ * `.up.sql` is well-named and has a matching `.down.sql`. Ordering is by
+ * version, which the zero-padded filenames make a plain string sort.
+ */
+export function discoverMigrations(dir: string = MIGRATIONS_DIR): Migration[] {
+  const files = readdirSync(dir);
+  const migrations = files
+    .filter((f) => f.endsWith(UP_SUFFIX))
+    .sort()
+    .map((up) => {
+      const base = up.slice(0, -UP_SUFFIX.length);
+      const match = /^(\d+)_(.+)$/.exec(base);
+      if (!match) {
+        throw new Error(
+          `Migration "${up}" must be named <version>_<name>${UP_SUFFIX}`,
+        );
+      }
+      const down = `${base}.down.sql`;
+      if (!files.includes(down)) {
+        throw new Error(`Migration "${up}" has no matching "${down}"`);
+      }
+      return {
+        version: match[1],
+        name: match[2],
+        upPath: join(dir, up),
+        downPath: join(dir, down),
+      } satisfies Migration;
+    });
+
+  const seen = new Set<string>();
+  for (const m of migrations) {
+    if (seen.has(m.version)) {
+      throw new Error(`Duplicate migration version "${m.version}"`);
+    }
+    seen.add(m.version);
+  }
+  return migrations;
+}
+
+/** Migrations not yet recorded as applied, in ascending order. */
+export function pendingMigrations(
+  all: Migration[],
+  applied: ReadonlySet<string>,
+): Migration[] {
+  return all.filter((m) => !applied.has(m.version));
+}
+
+/** The `steps` most-recently-applied migrations, newest first (revert order). */
+export function migrationsToRevert(
+  all: Migration[],
+  applied: ReadonlySet<string>,
+  steps: number,
+): Migration[] {
+  return all
+    .filter((m) => applied.has(m.version))
+    .reverse()
+    .slice(0, Math.max(0, steps));
+}
+
+async function ensureMigrationsTable(sql: SQL): Promise<void> {
+  await sql`
+    CREATE TABLE IF NOT EXISTS schema_migrations (
+      version    text        PRIMARY KEY,
+      name       text        NOT NULL,
+      applied_at timestamptz NOT NULL DEFAULT now()
+    )`;
+}
+
+async function appliedVersions(sql: SQL): Promise<Set<string>> {
+  const rows = (await sql`SELECT version FROM schema_migrations`) as Array<{
+    version: string;
+  }>;
+  return new Set(rows.map((r) => r.version));
+}
+
+/**
+ * Applies every pending migration in order. Each runs in its own transaction
+ * together with the `schema_migrations` insert, so a failing migration leaves
+ * neither half-applied DDL nor a bookkeeping row behind (Postgres DDL is
+ * transactional). Returns the versions applied.
+ */
+export async function migrateUp(
+  sql: SQL,
+  all: Migration[] = discoverMigrations(),
+): Promise<string[]> {
+  await ensureMigrationsTable(sql);
+  const pending = pendingMigrations(all, await appliedVersions(sql));
+  const applied: string[] = [];
+  for (const m of pending) {
+    const ddl = readFileSync(m.upPath, 'utf8');
+    await sql.begin(async (tx) => {
+      await tx.unsafe(ddl);
+      await tx`INSERT INTO schema_migrations (version, name) VALUES (${m.version}, ${m.name})`;
+    });
+    applied.push(m.version);
+  }
+  return applied;
+}
+
+/**
+ * Reverts the `steps` most recent migrations (default 1), newest first, each in
+ * a transaction with its bookkeeping delete. Returns the versions reverted.
+ */
+export async function migrateDown(
+  sql: SQL,
+  steps = 1,
+  all: Migration[] = discoverMigrations(),
+): Promise<string[]> {
+  await ensureMigrationsTable(sql);
+  const target = migrationsToRevert(all, await appliedVersions(sql), steps);
+  const reverted: string[] = [];
+  for (const m of target) {
+    const ddl = readFileSync(m.downPath, 'utf8');
+    await sql.begin(async (tx) => {
+      await tx.unsafe(ddl);
+      await tx`DELETE FROM schema_migrations WHERE version = ${m.version}`;
+    });
+    reverted.push(m.version);
+  }
+  return reverted;
+}
+
+export interface MigrationStatus extends Migration {
+  applied: boolean;
+}
+
+/** Every migration with whether it is currently applied, in order. */
+export async function migrationStatus(
+  sql: SQL,
+  all: Migration[] = discoverMigrations(),
+): Promise<MigrationStatus[]> {
+  await ensureMigrationsTable(sql);
+  const applied = await appliedVersions(sql);
+  return all.map((m) => ({ ...m, applied: applied.has(m.version) }));
+}
+
+async function main(): Promise<void> {
+  const command = process.argv[2] ?? 'up';
+  const sql = createSqlClient();
+  try {
+    switch (command) {
+      case 'up': {
+        const applied = await migrateUp(sql);
+        console.log(
+          applied.length
+            ? `Applied ${applied.length} migration(s): ${applied.join(', ')}`
+            : 'No pending migrations.',
+        );
+        break;
+      }
+      case 'down': {
+        const steps = Number(process.argv[3] ?? '1');
+        if (!Number.isInteger(steps) || steps < 1) {
+          throw new Error(`down expects a positive step count, got "${process.argv[3]}"`);
+        }
+        const reverted = await migrateDown(sql, steps);
+        console.log(
+          reverted.length
+            ? `Reverted ${reverted.length} migration(s): ${reverted.join(', ')}`
+            : 'Nothing to revert.',
+        );
+        break;
+      }
+      case 'status': {
+        for (const m of await migrationStatus(sql)) {
+          console.log(`${m.applied ? '✔' : '·'} ${m.version} ${m.name}`);
+        }
+        break;
+      }
+      default:
+        console.info(`Unknown command "${command}". Use: up | down [n] | status`);
+        process.exitCode = 1;
+    }
+  } finally {
+    await sql.close();
+  }
+}
+
+if (import.meta.main) {
+  await main();
+}


### PR DESCRIPTION
Closes #25. Stacked on #24 (merged).

Defines the MVP PostgreSQL schema and a migration system for `@schediochron/sql`. Every table expresses a model in `@schediochron/core` and the invariants its ADR fixes — the up migration cites the source inline.

## Schema (`migrations/0001_initial_schema.up.sql`)
- **`users`** — `username` unique, `email` unique-when-present, `role` check. Format/length checks mirror the Zod schema.
- **`user_credentials`** — the password hash lives here, **not** on `users`. See the deliberate deviation below.
- **`teams`** + **`team_members`** — membership is a join table with an `is_admin` flag. An admin *is* a member row, so `adminIds ⊆ memberIds` (ADR-004) is **structural**, not a cross-array check. "At least one admin" can't be a row constraint and is left to the Team repository (#28).
- **`time_entries`** — `end_time` null while running; two CHECK constraints encode running↔null / completed↔set and `start < end` (ADR-001). **No `duration` or `date` columns** (both derived). A **partial unique index** on `(user_id) WHERE status = 'running'` makes one-running-entry-per-user a database guarantee — a second clock-in raises a unique violation the repo maps to 409.
- **`refresh_tokens`** — `token` PK holds the *hash* of the opaque token; nullable `revoked_at` (ADR-003).

## Deliberate deviation: credentials in their own table
The issue lists `password_hash` as a `users` column, but the shipped `User` model and `UserRepository` (#126) are **credential-free** — ADR-002 fixes `passwordHash` as living "only in the persistence layer", never a field on `User`, never exposed. A NOT NULL `password_hash` on `users` would make `UserRepository.create(user: User)` unsatisfiable (nothing in `User` supplies it). Splitting it into `user_credentials` keeps `UserRepository` pure and fully implementable while keeping the hash NOT NULL where it is stored. The auth layer (#29/#30) owns this table; the repository never touches it.

## Migration runner (`src/migrate.ts`)
Dependency-free, consistent with the Bun-native stance. Tracks applied versions in `schema_migrations`; applies each migration (and its bookkeeping row) in a single transaction, so a failure leaves nothing half-applied. CLI: `migrate up | down [n] | status`. `createSqlClient` reads `DATABASE_URL` with **no default**.

## Verification
- `bun run build` / `typecheck` / `lint` ✅
- `bun test` — 12 unit tests over the runner's discovery, ordering, and pending/revert selection (pure logic) ✅

⚠️ **Not verified against a live PostgreSQL in this environment** (no Docker/psql available here). The SQL and runner are written to run under the Docker Compose setup (#36), which stands up the database the repository integration tests (#26–#28) will use. Reversibility is guaranteed by construction via paired up/down files; an end-to-end up→down→up check should run once #36 lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)