### PR TITLE
feature(27) + [sql] implement User repository

### DIFF
--- a/libs/sql/src/index.ts
+++ b/libs/sql/src/index.ts
@@ -15,3 +15,6 @@ export {
   migrateDown,
   migrationStatus,
 } from './migrate.js';
+
+export type { DuplicateUserField } from './user-repository.js';
+export { DuplicateUserError, UserRepository } from './user-repository.js';

--- a/libs/sql/src/user-repository.spec.ts
+++ b/libs/sql/src/user-repository.spec.ts
@@ -1,0 +1,151 @@
+import { afterAll, beforeAll, describe, expect, it } from 'bun:test';
+import { randomUUID } from 'node:crypto';
+import type { SQL } from 'bun';
+import type { User } from '@schediochron/core';
+import { createSqlClient } from './db.js';
+import { migrateUp } from './migrate.js';
+import { DuplicateUserError, UserRepository } from './user-repository.js';
+
+// A well-formed User with sensible defaults; override per test.
+function makeUser(overrides: Partial<User> = {}): User {
+  const now = new Date().toISOString();
+  return {
+    id: randomUUID(),
+    username: `user_${randomUUID().slice(0, 8)}`,
+    displayName: 'Ada Lovelace',
+    email: `${randomUUID().slice(0, 8)}@example.com`,
+    role: 'member',
+    createdAt: now,
+    updatedAt: now,
+    ...overrides,
+  };
+}
+
+// Pure, DB-free assertions on the shapes the repository exposes.
+describe('DuplicateUserError', () => {
+  it('names the offending field and carries the driver error as cause', () => {
+    const cause = { code: '23505', constraint: 'users_email_key' };
+    const err = new DuplicateUserError('email', { cause });
+    expect(err).toBeInstanceOf(Error);
+    expect(err.name).toBe('DuplicateUserError');
+    expect(err.field).toBe('email');
+    expect(err.message).toContain('email');
+    expect(err.cause).toBe(cause);
+  });
+
+  it('describes an unattributable violation without a column name', () => {
+    const err = new DuplicateUserError('unknown');
+    expect(err.field).toBe('unknown');
+    expect(err.message).toContain('unique user field');
+  });
+});
+
+// DB-backed round-trips. There is no live PostgreSQL in CI/dev here, so these
+// skip unless DATABASE_URL points at a disposable database.
+describe.skipIf(!process.env.DATABASE_URL)('UserRepository (PostgreSQL)', () => {
+  let sql: SQL;
+  let repo: UserRepository;
+
+  beforeAll(async () => {
+    sql = createSqlClient();
+    await migrateUp(sql);
+    repo = new UserRepository(sql);
+  });
+
+  afterAll(async () => {
+    await sql?.close();
+  });
+
+  it('creates a user and reads it back by id and by username', async () => {
+    const user = makeUser();
+    const created = await repo.create(user);
+
+    expect(created.id).toBe(user.id);
+    expect(created.username).toBe(user.username);
+    expect(created.displayName).toBe(user.displayName);
+    expect(created.email).toBe(user.email);
+    expect(created.role).toBe('member');
+    // Timestamps are set by the persistence layer and are ISO 8601 UTC.
+    expect(created.createdAt).toMatch(/Z$/);
+    expect(created.updatedAt).toMatch(/Z$/);
+    expect(new Date(created.createdAt).toISOString()).toBe(created.createdAt);
+
+    expect(await repo.findById(user.id)).toEqual(created);
+    expect(await repo.findByUsername(user.username)).toEqual(created);
+  });
+
+  it('returns null for an unknown id or username', async () => {
+    expect(await repo.findById(randomUUID())).toBeNull();
+    expect(await repo.findByUsername(`missing_${randomUUID().slice(0, 8)}`)).toBeNull();
+  });
+
+  it('maps null displayName and email to null (never empty string)', async () => {
+    const user = makeUser({ displayName: null, email: null });
+    const created = await repo.create(user);
+
+    expect(created.displayName).toBeNull();
+    expect(created.email).toBeNull();
+
+    const fetched = await repo.findById(user.id);
+    expect(fetched?.displayName).toBeNull();
+    expect(fetched?.email).toBeNull();
+  });
+
+  it('update refreshes updatedAt and persists mutable fields', async () => {
+    const created = await repo.create(makeUser({ role: 'member' }));
+    // Ensure the clock advances so updatedAt is observably newer.
+    await new Promise((resolve) => setTimeout(resolve, 5));
+
+    const updated = await repo.update({
+      ...created,
+      displayName: 'Grace Hopper',
+      email: null,
+      role: 'admin',
+    });
+
+    expect(updated.displayName).toBe('Grace Hopper');
+    expect(updated.email).toBeNull();
+    expect(updated.role).toBe('admin');
+    expect(updated.createdAt).toBe(created.createdAt);
+    expect(new Date(updated.updatedAt).getTime()).toBeGreaterThan(
+      new Date(created.updatedAt).getTime(),
+    );
+  });
+
+  it('delete removes the row; deleting an unknown id is a no-op', async () => {
+    const created = await repo.create(makeUser());
+    await repo.delete(created.id);
+    expect(await repo.findById(created.id)).toBeNull();
+
+    // No throw, no effect.
+    await repo.delete(randomUUID());
+  });
+
+  it('raises DuplicateUserError on a duplicate username', async () => {
+    const first = await repo.create(makeUser());
+    const clash = makeUser({ username: first.username });
+
+    let caught: unknown;
+    try {
+      await repo.create(clash);
+    } catch (err) {
+      caught = err;
+    }
+    expect(caught).toBeInstanceOf(DuplicateUserError);
+    expect((caught as DuplicateUserError).field).toBe('username');
+  });
+
+  it('raises DuplicateUserError on a duplicate email', async () => {
+    const first = await repo.create(makeUser());
+    const clash = makeUser({ email: first.email });
+
+    let caught: unknown;
+    try {
+      await repo.create(clash);
+    } catch (err) {
+      caught = err;
+    }
+    expect(caught).toBeInstanceOf(DuplicateUserError);
+    expect((caught as DuplicateUserError).field).toBe('email');
+  });
+});

--- a/libs/sql/src/user-repository.ts
+++ b/libs/sql/src/user-repository.ts
@@ -1,0 +1,184 @@
+import type { SQL } from 'bun';
+import type {
+  User,
+  UserRole,
+  UserRepository as UserRepositoryContract,
+} from '@schediochron/core';
+
+/**
+ * Which unique field a {@link DuplicateUserError} is about. `unknown` covers a
+ * unique violation whose constraint we could not attribute to a specific column.
+ */
+export type DuplicateUserField = 'username' | 'email' | 'unknown';
+
+/**
+ * A `username` or `email` uniqueness violation, surfaced as a typed error so the
+ * API can answer 409 instead of leaking a raw driver error. Thrown on the
+ * Postgres unique-violation SQLSTATE `23505`; `field` names the offending column
+ * where the constraint makes it clear.
+ */
+export class DuplicateUserError extends Error {
+  readonly field: DuplicateUserField;
+
+  constructor(field: DuplicateUserField, options?: { cause?: unknown }) {
+    const subject =
+      field === 'unknown' ? 'A unique user field' : `The ${field}`;
+    super(`${subject} is already taken`, options);
+    this.name = 'DuplicateUserError';
+    this.field = field;
+  }
+}
+
+/** The `users` columns this repository owns — credentials live elsewhere. */
+interface UserRow {
+  id: string;
+  username: string;
+  display_name: string | null;
+  email: string | null;
+  role: UserRole;
+  created_at: Date | string;
+  updated_at: Date | string;
+}
+
+// TODO(#31): extract shared row mapping once a second repository needs it; kept
+// local for now because sibling repositories land on this package concurrently.
+
+/** Normalises a `timestamptz` (Date or string from the driver) to ISO 8601 UTC. */
+function toIsoUtc(value: Date | string): string {
+  return (value instanceof Date ? value : new Date(value)).toISOString();
+}
+
+/** Maps a `users` row to the credential-free {@link User} model. */
+function mapRow(row: UserRow): User {
+  return {
+    id: row.id,
+    username: row.username,
+    displayName: row.display_name,
+    email: row.email,
+    role: row.role,
+    createdAt: toIsoUtc(row.created_at),
+    updatedAt: toIsoUtc(row.updated_at),
+  };
+}
+
+/** A Postgres error carrying the fields we inspect for unique violations. */
+interface PgUniqueViolation {
+  code: string;
+  constraint?: string;
+  detail?: string;
+}
+
+const UNIQUE_VIOLATION = '23505';
+
+function asUniqueViolation(err: unknown): PgUniqueViolation | null {
+  if (
+    typeof err === 'object' &&
+    err !== null &&
+    'code' in err &&
+    (err as { code: unknown }).code === UNIQUE_VIOLATION
+  ) {
+    return err as PgUniqueViolation;
+  }
+  return null;
+}
+
+/** Attributes a unique violation to a column via its constraint/detail text. */
+function duplicateFieldOf(violation: PgUniqueViolation): DuplicateUserField {
+  const haystack = `${violation.constraint ?? ''} ${violation.detail ?? ''}`;
+  if (haystack.includes('username')) return 'username';
+  if (haystack.includes('email')) return 'email';
+  return 'unknown';
+}
+
+/**
+ * Turns a driver error into a {@link DuplicateUserError} when it is a unique
+ * violation, otherwise rethrows it unchanged.
+ */
+function rethrow(err: unknown): never {
+  const violation = asUniqueViolation(err);
+  if (violation) {
+    throw new DuplicateUserError(duplicateFieldOf(violation), { cause: err });
+  }
+  throw err;
+}
+
+/**
+ * PostgreSQL implementation of the `UserRepository` contract, using Bun's native
+ * `SQL` client.
+ *
+ * Credential-free by design (ADR-002): this repository maps only the `users`
+ * columns and never reads or writes `user_credentials` or any password hash —
+ * the auth layer (#29/#30) owns credentials. `create` works precisely because
+ * the hash is not this repository's concern.
+ */
+export class UserRepository implements UserRepositoryContract {
+  constructor(private readonly sql: SQL) {}
+
+  async findById(id: string): Promise<User | null> {
+    const rows = (await this.sql`
+      SELECT id, username, display_name, email, role, created_at, updated_at
+      FROM users
+      WHERE id = ${id}
+    `) as UserRow[];
+    return rows.length ? mapRow(rows[0]) : null;
+  }
+
+  async findByUsername(username: string): Promise<User | null> {
+    const rows = (await this.sql`
+      SELECT id, username, display_name, email, role, created_at, updated_at
+      FROM users
+      WHERE username = ${username}
+    `) as UserRow[];
+    return rows.length ? mapRow(rows[0]) : null;
+  }
+
+  async findAll(): Promise<User[]> {
+    const rows = (await this.sql`
+      SELECT id, username, display_name, email, role, created_at, updated_at
+      FROM users
+      ORDER BY created_at, id
+    `) as UserRow[];
+    return rows.map(mapRow);
+  }
+
+  async create(user: User): Promise<User> {
+    try {
+      // created_at/updated_at are set by the persistence layer (DEFAULT now()),
+      // not taken from the item, per the CrudRepository contract.
+      const rows = (await this.sql`
+        INSERT INTO users (id, username, display_name, email, role)
+        VALUES (${user.id}, ${user.username}, ${user.displayName}, ${user.email}, ${user.role})
+        RETURNING id, username, display_name, email, role, created_at, updated_at
+      `) as UserRow[];
+      return mapRow(rows[0]);
+    } catch (err) {
+      rethrow(err);
+    }
+  }
+
+  async update(user: User): Promise<User> {
+    try {
+      const rows = (await this.sql`
+        UPDATE users
+        SET username = ${user.username},
+            display_name = ${user.displayName},
+            email = ${user.email},
+            role = ${user.role},
+            updated_at = now()
+        WHERE id = ${user.id}
+        RETURNING id, username, display_name, email, role, created_at, updated_at
+      `) as UserRow[];
+      if (!rows.length) {
+        throw new Error(`Cannot update user ${user.id}: not found`);
+      }
+      return mapRow(rows[0]);
+    } catch (err) {
+      rethrow(err);
+    }
+  }
+
+  async delete(id: string): Promise<void> {
+    // Deleting an unknown id is a no-op: no row matches, nothing happens.
+    await this.sql`DELETE FROM users WHERE id = ${id}`;
+  }
+}


### PR DESCRIPTION
Closes #27.

Implements `UserRepository` in `@schediochron/sql` — the PostgreSQL adapter for the core `UserRepository` contract — using Bun's native `SQL` client.

**Stacked on #25.** Targets `feature/25-define-db-schema-and-migrations` (the schema/migrations this repository maps against), not `main`.

## What it does
- Implements exactly the contract surface: `findById`, `findByUsername`, `findAll`, `create`, `update`, `delete`. No extra public methods.
- Maps only the `users` columns (`id`, `username`, `display_name`, `email`, `role`, `created_at`, `updated_at`).
- `null` displayName/email round-trips as `null` (never empty string); `timestamptz` normalises to ISO 8601 UTC; `update` refreshes `updated_at`.
- `findById`/`findByUsername` return `null` on absence; `delete` of an unknown id is a no-op.

## Credential-free by design (ADR-002)
`User` has no `passwordHash`, and password hashes live in a **separate** `user_credentials` table, not on `users`. This repository never reads or writes `user_credentials` or any hash — the auth layer (#29/#30) owns credentials. `create(user: User)` works precisely because the hash is not its concern.

## Typed 409-mappable errors
Unique violations (Postgres SQLSTATE `23505`) surface as a typed, exported `DuplicateUserError` (with a `field: 'username' | 'email' | 'unknown'`) instead of a raw driver error, so the API can answer 409 and tell the user which field clashed.

## Tests
Pure `DuplicateUserError` checks run unconditionally. DB-backed round-trips (create→find, update refreshes `updatedAt`, delete + delete-unknown no-op, null mapping, duplicate username/email) are gated with `describe.skipIf(!process.env.DATABASE_URL)` — **they skip without `DATABASE_URL`**, since there is no live PostgreSQL in this environment.

Verified: `build`, `typecheck`, `lint` clean; `bun test` → 14 pass / 9 skip / 0 fail.

🤖 Generated with [Claude Code](https://claude.com/claude-code)