### PR TITLE
feature(26) + [sql] implement TimeEntry repository

### DIFF
--- a/libs/sql/src/index.ts
+++ b/libs/sql/src/index.ts
@@ -6,8 +6,6 @@
 
 export { createSqlClient } from './db.js';
 
-export { TeamSqlRepository, LastAdminError } from './team-repository.js';
-
 export type { Migration, MigrationStatus } from './migrate.js';
 export {
   discoverMigrations,
@@ -18,5 +16,12 @@ export {
   migrationStatus,
 } from './migrate.js';
 
+export {
+  SqlTimeEntryRepository,
+  RunningEntryExistsError,
+} from './time-entry-repository.js';
+
 export type { DuplicateUserField } from './user-repository.js';
 export { DuplicateUserError, UserRepository } from './user-repository.js';
+
+export { TeamSqlRepository, LastAdminError } from './team-repository.js';

--- a/libs/sql/src/time-entry-repository.spec.ts
+++ b/libs/sql/src/time-entry-repository.spec.ts
@@ -1,0 +1,211 @@
+import {
+  afterAll,
+  afterEach,
+  beforeAll,
+  describe,
+  expect,
+  it,
+} from 'bun:test';
+import type { SQL } from 'bun';
+import { validateTimeEntry, type TimeEntry } from '@schediochron/core';
+import { createSqlClient } from './db.js';
+import { migrateUp } from './migrate.js';
+import {
+  mapRowToTimeEntry,
+  zeroSeconds,
+  RunningEntryExistsError,
+  SqlTimeEntryRepository,
+} from './time-entry-repository.js';
+
+// --- Pure logic: row↔model mapping, always run (no database needed). ---
+
+describe('mapRowToTimeEntry', () => {
+  const base = {
+    id: '11111111-1111-4111-8111-111111111111',
+    user_id: '22222222-2222-4222-8222-222222222222',
+    start_time: new Date('2024-01-01T09:00:00.000Z'),
+    end_time: new Date('2024-01-01T10:00:00.000Z'),
+    status: 'completed',
+    note: 'shipped it',
+    created_at: new Date('2024-01-01T09:00:12.000Z'),
+    updated_at: new Date('2024-01-01T10:00:34.000Z'),
+  };
+
+  it('maps a completed row to the model with ISO 8601 UTC timestamps', () => {
+    const entry = mapRowToTimeEntry(base);
+    expect(entry).toEqual({
+      id: base.id,
+      userId: base.user_id,
+      startTime: '2024-01-01T09:00:00.000Z',
+      endTime: '2024-01-01T10:00:00.000Z',
+      status: 'completed',
+      note: 'shipped it',
+      createdAt: '2024-01-01T09:00:12.000Z',
+      updatedAt: '2024-01-01T10:00:34.000Z',
+    });
+    expect(validateTimeEntry(entry).success).toBe(true);
+  });
+
+  it('keeps endTime null while running', () => {
+    const entry = mapRowToTimeEntry({
+      ...base,
+      status: 'running',
+      end_time: null,
+    });
+    expect(entry.endTime).toBeNull();
+    expect(entry.status).toBe('running');
+    expect(validateTimeEntry(entry).success).toBe(true);
+  });
+
+  it('maps an absent note to null, never an empty string', () => {
+    expect(mapRowToTimeEntry({ ...base, note: null }).note).toBeNull();
+    expect(mapRowToTimeEntry({ ...base, note: '' }).note).toBeNull();
+  });
+
+  it('accepts string timestamps from the driver', () => {
+    const entry = mapRowToTimeEntry({
+      ...base,
+      start_time: '2024-01-01T09:00:00Z',
+      end_time: '2024-01-01T10:00:00Z',
+    });
+    expect(entry.startTime).toBe('2024-01-01T09:00:00.000Z');
+    expect(entry.endTime).toBe('2024-01-01T10:00:00.000Z');
+  });
+});
+
+describe('zeroSeconds', () => {
+  it('floors seconds and milliseconds to zero (minute precision)', () => {
+    expect(zeroSeconds('2024-01-01T23:40:59.678Z').toISOString()).toBe(
+      '2024-01-01T23:40:00.000Z',
+    );
+  });
+
+  it('leaves an already-zeroed timestamp unchanged', () => {
+    expect(zeroSeconds('2024-01-01T23:40:00.000Z').toISOString()).toBe(
+      '2024-01-01T23:40:00.000Z',
+    );
+  });
+});
+
+describe('RunningEntryExistsError', () => {
+  it('carries the userId and a cause', () => {
+    const cause = new Error('unique violation');
+    const err = new RunningEntryExistsError('user-1', { cause });
+    expect(err).toBeInstanceOf(Error);
+    expect(err.name).toBe('RunningEntryExistsError');
+    expect(err.userId).toBe('user-1');
+    expect(err.cause).toBe(cause);
+  });
+});
+
+// --- Integration: gated on DATABASE_URL; there is no Postgres in CI, so these
+// skip there. They exercise the running→completed lifecycle, findRunning, the
+// one-running-entry rule, and find filters against a real database. ---
+
+const uuid = (): string => crypto.randomUUID();
+
+function makeEntry(userId: string, overrides: Partial<TimeEntry> = {}): TimeEntry {
+  const now = new Date().toISOString();
+  return {
+    id: uuid(),
+    userId,
+    startTime: '2024-01-01T09:00:00Z',
+    endTime: null,
+    status: 'running',
+    note: null,
+    createdAt: now,
+    updatedAt: now,
+    ...overrides,
+  };
+}
+
+describe.skipIf(!process.env.DATABASE_URL)('SqlTimeEntryRepository (db)', () => {
+  let sql: SQL;
+  let repo: SqlTimeEntryRepository;
+  let userId: string;
+
+  beforeAll(async () => {
+    sql = createSqlClient();
+    repo = new SqlTimeEntryRepository(sql);
+    await migrateUp(sql);
+    userId = uuid();
+    await sql`
+      INSERT INTO users (id, username, role)
+      VALUES (${userId}, ${`test_${userId.slice(0, 8)}`}, 'member')`;
+  });
+
+  afterEach(async () => {
+    await sql`DELETE FROM time_entries WHERE user_id = ${userId}`;
+  });
+
+  afterAll(async () => {
+    await sql`DELETE FROM users WHERE id = ${userId}`;
+    await sql.close();
+  });
+
+  it('runs the running → completed lifecycle', async () => {
+    const created = await repo.create(
+      makeEntry(userId, { startTime: '2024-01-01T09:00:00Z', note: 'work' }),
+    );
+    expect(created.status).toBe('running');
+    expect(created.endTime).toBeNull();
+    expect(created.note).toBe('work');
+    expect(validateTimeEntry(created).success).toBe(true);
+
+    const running = await repo.findRunning(userId);
+    expect(running?.id).toBe(created.id);
+
+    const completed = await repo.update({
+      ...created,
+      status: 'completed',
+      endTime: '2024-01-01T10:00:00Z',
+    });
+    expect(completed.status).toBe('completed');
+    expect(completed.endTime).toBe('2024-01-01T10:00:00.000Z');
+    expect(validateTimeEntry(completed).success).toBe(true);
+
+    expect(await repo.findRunning(userId)).toBeNull();
+  });
+
+  it('rejects a second running entry with RunningEntryExistsError', async () => {
+    await repo.create(makeEntry(userId, { startTime: '2024-01-01T09:00:00Z' }));
+    await expect(
+      repo.create(makeEntry(userId, { startTime: '2024-01-01T11:00:00Z' })),
+    ).rejects.toBeInstanceOf(RunningEntryExistsError);
+  });
+
+  it('findRunning returns null when clocked out', async () => {
+    expect(await repo.findRunning(userId)).toBeNull();
+  });
+
+  it('applies find filters (status, from/to bound start_time inclusively)', async () => {
+    await repo.create(
+      makeEntry(userId, {
+        status: 'completed',
+        startTime: '2024-01-01T09:00:00Z',
+        endTime: '2024-01-01T10:00:00Z',
+      }),
+    );
+    await repo.create(
+      makeEntry(userId, {
+        status: 'completed',
+        startTime: '2024-01-02T09:00:00Z',
+        endTime: '2024-01-02T10:00:00Z',
+      }),
+    );
+    await repo.create(
+      makeEntry(userId, { status: 'running', startTime: '2024-01-03T09:00:00Z' }),
+    );
+
+    expect(await repo.find({ userId })).toHaveLength(3);
+    expect(await repo.find({ userId, status: 'running' })).toHaveLength(1);
+    expect(await repo.find({ userId, status: 'completed' })).toHaveLength(2);
+
+    const bounded = await repo.find({
+      userId,
+      from: '2024-01-01T09:00:00Z',
+      to: '2024-01-02T09:00:00Z',
+    });
+    expect(bounded).toHaveLength(2);
+  });
+});

--- a/libs/sql/src/time-entry-repository.ts
+++ b/libs/sql/src/time-entry-repository.ts
@@ -1,0 +1,234 @@
+import type { SQL } from 'bun';
+import type {
+  TimeEntry,
+  TimeEntryStatus,
+  TimeEntryRepository,
+} from '@schediochron/core';
+
+/**
+ * The `time_entries` row as Bun's SQL client hands it back: snake_case columns,
+ * `timestamptz` values as `Date` (occasionally a string depending on driver
+ * config, hence the union), `note`/`end_time` nullable.
+ */
+interface TimeEntryRow {
+  id: string;
+  user_id: string;
+  start_time: Date | string;
+  end_time: Date | string | null;
+  status: string;
+  note: string | null;
+  created_at: Date | string;
+  updated_at: Date | string;
+}
+
+/** The partial unique index enforcing one running entry per user (ADR-001). */
+const RUNNING_ENTRY_INDEX = 'time_entries_one_running_per_user';
+
+/** Postgres SQLSTATE for a unique-violation. */
+const UNIQUE_VIOLATION = '23505';
+
+/**
+ * A user already has an open entry, so a second clock-in was rejected by the
+ * `time_entries_one_running_per_user` index. The API turns this into a 409.
+ *
+ * The one-running-entry invariant lives in the database (the partial unique
+ * index); this class is only the typed surface for the violation it raises, so
+ * the rule is never re-checked in application code.
+ */
+export class RunningEntryExistsError extends Error {
+  readonly userId: string;
+
+  constructor(userId: string, options?: { cause?: unknown }) {
+    super(`User ${userId} already has a running time entry.`, options);
+    this.name = 'RunningEntryExistsError';
+    this.userId = userId;
+  }
+}
+
+// TODO(#…): extract shared row mapping — other repositories (#27, #28) map
+// timestamptz→ISO the same way; kept local for now while the package is edited
+// concurrently.
+
+/** A `timestamptz` value from the driver as an ISO 8601 UTC string. */
+function dbTimestampToIso(value: Date | string): string {
+  return value instanceof Date
+    ? value.toISOString()
+    : new Date(value).toISOString();
+}
+
+/**
+ * The instant for a model timestamp with its seconds (and milliseconds) floored
+ * to zero — minute precision, per ADR-001, applied on every write.
+ */
+export function zeroSeconds(iso: string): Date {
+  const date = new Date(iso);
+  date.setUTCSeconds(0, 0);
+  return date;
+}
+
+/** Empty notes are stored and returned as `null`, never `''` (ADR-001). */
+function normalizeNote(note: string | null): string | null {
+  return note === '' ? null : note;
+}
+
+/** Maps a stored row to the `TimeEntry` model exactly. */
+export function mapRowToTimeEntry(row: TimeEntryRow): TimeEntry {
+  return {
+    id: row.id,
+    userId: row.user_id,
+    startTime: dbTimestampToIso(row.start_time),
+    endTime: row.end_time === null ? null : dbTimestampToIso(row.end_time),
+    status: row.status as TimeEntryStatus,
+    note: normalizeNote(row.note),
+    createdAt: dbTimestampToIso(row.created_at),
+    updatedAt: dbTimestampToIso(row.updated_at),
+  };
+}
+
+/** True when `err` is the unique-violation raised by a second running entry. */
+function isRunningEntryUniqueViolation(err: unknown): boolean {
+  if (typeof err !== 'object' || err === null) {
+    return false;
+  }
+  const e = err as {
+    code?: unknown;
+    constraint?: unknown;
+    detail?: unknown;
+    message?: unknown;
+  };
+  if (e.code !== UNIQUE_VIOLATION) {
+    return false;
+  }
+  if (e.constraint === RUNNING_ENTRY_INDEX) {
+    return true;
+  }
+  // Fall back to the message when the driver doesn't populate `constraint`,
+  // so a primary-key collision (a different unique index) isn't misread.
+  const detail = typeof e.detail === 'string' ? e.detail : '';
+  const message = typeof e.message === 'string' ? e.message : '';
+  return `${detail} ${message}`.includes(RUNNING_ENTRY_INDEX);
+}
+
+/**
+ * PostgreSQL-backed {@link TimeEntryRepository} over Bun's native SQL client.
+ *
+ * Schema-enforced invariants (one running entry per user, status↔end_time,
+ * start<end) are left to the database; the only application-level translation is
+ * surfacing the running-entry unique violation as {@link RunningEntryExistsError}
+ * so the API can answer 409. CHECK-constraint violations propagate unchanged.
+ */
+export class SqlTimeEntryRepository implements TimeEntryRepository {
+  constructor(private readonly sql: SQL) {}
+
+  async findById(id: string): Promise<TimeEntry | null> {
+    const rows = (await this
+      .sql`SELECT * FROM time_entries WHERE id = ${id}`) as TimeEntryRow[];
+    const row = rows[0];
+    return row ? mapRowToTimeEntry(row) : null;
+  }
+
+  async findAll(): Promise<TimeEntry[]> {
+    const rows = (await this
+      .sql`SELECT * FROM time_entries ORDER BY start_time, id`) as TimeEntryRow[];
+    return rows.map(mapRowToTimeEntry);
+  }
+
+  async create(item: TimeEntry): Promise<TimeEntry> {
+    try {
+      const rows = (await this.sql`
+        INSERT INTO time_entries (id, user_id, start_time, end_time, status, note)
+        VALUES (
+          ${item.id},
+          ${item.userId},
+          ${zeroSeconds(item.startTime)},
+          ${item.endTime === null ? null : zeroSeconds(item.endTime)},
+          ${item.status},
+          ${normalizeNote(item.note)}
+        )
+        RETURNING *`) as TimeEntryRow[];
+      return mapRowToTimeEntry(rows[0]);
+    } catch (err) {
+      throw this.translateWriteError(err, item.userId);
+    }
+  }
+
+  async update(item: TimeEntry): Promise<TimeEntry> {
+    let rows: TimeEntryRow[];
+    try {
+      rows = (await this.sql`
+        UPDATE time_entries
+        SET start_time = ${zeroSeconds(item.startTime)},
+            end_time = ${item.endTime === null ? null : zeroSeconds(item.endTime)},
+            status = ${item.status},
+            note = ${normalizeNote(item.note)},
+            updated_at = now()
+        WHERE id = ${item.id}
+        RETURNING *`) as TimeEntryRow[];
+    } catch (err) {
+      throw this.translateWriteError(err, item.userId);
+    }
+    const row = rows[0];
+    if (!row) {
+      throw new Error(`TimeEntry ${item.id} not found`);
+    }
+    return mapRowToTimeEntry(row);
+  }
+
+  async delete(id: string): Promise<void> {
+    await this.sql`DELETE FROM time_entries WHERE id = ${id}`;
+  }
+
+  async findRunning(userId: string): Promise<TimeEntry | null> {
+    const rows = (await this.sql`
+      SELECT * FROM time_entries
+      WHERE user_id = ${userId} AND status = 'running'`) as TimeEntryRow[];
+    const row = rows[0];
+    return row ? mapRowToTimeEntry(row) : null;
+  }
+
+  async find(filter: {
+    userId?: string;
+    status?: TimeEntryStatus;
+    from?: string;
+    to?: string;
+  }): Promise<TimeEntry[]> {
+    const conditions: SQL.Query<unknown>[] = [];
+    if (filter.userId !== undefined) {
+      conditions.push(this.sql`user_id = ${filter.userId}`);
+    }
+    if (filter.status !== undefined) {
+      conditions.push(this.sql`status = ${filter.status}`);
+    }
+    if (filter.from !== undefined) {
+      conditions.push(this.sql`start_time >= ${new Date(filter.from)}`);
+    }
+    if (filter.to !== undefined) {
+      conditions.push(this.sql`start_time <= ${new Date(filter.to)}`);
+    }
+
+    let where: SQL.Query<unknown> = this.sql``;
+    if (conditions.length > 0) {
+      let combined = conditions[0];
+      for (let i = 1; i < conditions.length; i++) {
+        combined = this.sql`${combined} AND ${conditions[i]}`;
+      }
+      where = this.sql`WHERE ${combined}`;
+    }
+
+    const rows = (await this
+      .sql`SELECT * FROM time_entries ${where} ORDER BY start_time, id`) as TimeEntryRow[];
+    return rows.map(mapRowToTimeEntry);
+  }
+
+  /**
+   * Maps a write failure to a typed error the API layer understands, or returns
+   * it unchanged. Only the running-entry unique violation is translated; CHECK
+   * violations propagate so their message reaches the caller intact.
+   */
+  private translateWriteError(err: unknown, userId: string): unknown {
+    if (isRunningEntryUniqueViolation(err)) {
+      return new RunningEntryExistsError(userId, { cause: err });
+    }
+    return err;
+  }
+}


### PR DESCRIPTION
Closes #26.

Stacked on #25 (`feature/25-define-db-schema-and-migrations`) — that branch is not yet merged, so this PR targets it as its base rather than `main`.

## What this implements
`SqlTimeEntryRepository` in `@schediochron/sql`: the PostgreSQL implementation of `TimeEntryRepository` from `@schediochron/core`, over Bun's native `SQL` client (constructor takes a `SQL` instance). Exactly the interface's methods — `findById`, `findAll`, `create`, `update`, `delete`, `findRunning`, `find` — and no public methods it doesn't declare.

## Design decisions
- **Row ↔ model mapping is exact.** `timestamptz` values map to ISO 8601 UTC strings on read; `startTime`/`endTime` have their seconds (and milliseconds) floored to zero on write (`zeroSeconds`), per ADR-001. `endTime` is `null` while running; `note` is `null`, never an empty string; `createdAt`/`updatedAt` are set by the database (`now()` default / `updated_at = now()` on update).
- **`findRunning`** resolves the single running entry via `WHERE user_id = $ AND status = 'running'` — it does not load history.
- **`find`** applies only the criteria present; `from`/`to` bound `start_time` inclusively (`>=` / `<=`), composed as SQL fragments.
- **Typed error for 409.** Schema-enforced invariants are not re-checked in application code. The one-running-per-user partial unique index (`time_entries_one_running_per_user`) raising a unique violation (SQLSTATE `23505`) is surfaced as an exported `RunningEntryExistsError` (matched by constraint name, with a message fallback so a PK collision isn't misread). This translation is applied on both `create` and `update`. `CHECK` violations (`time_entries_status_end_time`, `time_entries_interval`) propagate unchanged.
- Mapping/`zeroSeconds` helpers are kept local to the file with a `// TODO(#…)` note to extract shared row mapping later, since sibling repositories (#27/#28) are being written concurrently.

## Tests
- **Unconditional unit tests** for the pure logic: row→model mapping (completed, running, empty-note→null, string timestamps), `zeroSeconds`, and `RunningEntryExistsError`.
- **DATABASE_URL-gated integration tests** (`describe.skipIf(!process.env.DATABASE_URL)`) covering the running→completed lifecycle, `findRunning`, the one-running-entry rule (a second running `create` throws `RunningEntryExistsError`), and `find` filters. **There is no PostgreSQL in the build environment, so these skip there** and run only against a real database.

Verification (this branch): build, typecheck, lint all clean; `bun test` for the package is 19 pass / 6 skip / 0 fail.

🤖 Generated with [Claude Code](https://claude.com/claude-code)