### PR TITLE
feature(36) + [repo] docker compose for local development

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,19 @@
+# Copy to .env for `docker compose up`. `.env` is git-ignored.
+# These defaults work as-is; override only if a port is taken.
+
+# PostgreSQL
+POSTGRES_USER=schediochron
+POSTGRES_PASSWORD=schediochron
+POSTGRES_DB=schediochron
+POSTGRES_PORT=5432
+
+# Connection string used by the API and the migration runner. The host is the
+# compose service name `postgres`; use `localhost` if you run them on the host.
+DATABASE_URL=postgres://schediochron:schediochron@postgres:5432/schediochron
+
+# Host ports the API and web dev server are published on.
+API_PORT=3000
+WEB_PORT=4200
+
+# FontAwesome Pro token — required to install the frontend (see CONTRIBUTING.md).
+FONTAWESOME_TOKEN=

--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 # See https://docs.github.com/en/get-started/getting-started-with-git/ignoring-files for more about ignoring files.
 .npmrc
 .envrc
+.env
 
 # compiled output
 dist

--- a/README.md
+++ b/README.md
@@ -79,6 +79,22 @@ bun install
 bun run dev
 ```
 
+### Full stack with Docker Compose
+
+To run the whole stack — PostgreSQL, the API, and the web dev server — with one
+command:
+
+```bash
+cp .env.example .env        # then set FONTAWESOME_TOKEN (see CONTRIBUTING.md)
+docker compose up
+```
+
+This starts PostgreSQL, applies the database migrations automatically, then
+brings up the API (http://localhost:3000) and the React dev server
+(http://localhost:4200). The repository is bind-mounted, so edits hot-reload.
+Stop with `docker compose down`, or `docker compose down -v` to also drop the
+database volume.
+
 ### Common Commands
 
 ```bash

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,92 @@
+# Local development stack — `docker compose up` brings up PostgreSQL, runs the
+# migrations, then starts the API and the React dev server. The repository is
+# bind-mounted so edits on the host hot-reload inside the containers; a named
+# volume holds node_modules so the container's Linux binaries never clash with
+# the host's.
+name: schediochron
+
+services:
+  postgres:
+    image: postgres:16-alpine
+    environment:
+      POSTGRES_USER: ${POSTGRES_USER:-schediochron}
+      POSTGRES_PASSWORD: ${POSTGRES_PASSWORD:-schediochron}
+      POSTGRES_DB: ${POSTGRES_DB:-schediochron}
+    ports:
+      - '${POSTGRES_PORT:-5432}:5432'
+    volumes:
+      - postgres-data:/var/lib/postgresql/data
+    healthcheck:
+      test:
+        [
+          'CMD-SHELL',
+          'pg_isready -U ${POSTGRES_USER:-schediochron} -d ${POSTGRES_DB:-schediochron}',
+        ]
+      interval: 5s
+      timeout: 5s
+      retries: 10
+
+  # One-shot: populate the shared node_modules volume once so the long-running
+  # services don't each race to install.
+  deps:
+    image: oven/bun:1.3
+    working_dir: /app
+    environment:
+      FONTAWESOME_TOKEN: ${FONTAWESOME_TOKEN:-}
+    volumes:
+      - .:/app
+      - node-modules:/app/node_modules
+    command: ['bun', 'install', '--frozen-lockfile']
+
+  # One-shot: apply pending migrations, then exit. The API waits on this.
+  migrate:
+    image: oven/bun:1.3
+    working_dir: /app
+    environment:
+      DATABASE_URL: ${DATABASE_URL:-postgres://schediochron:schediochron@postgres:5432/schediochron}
+    volumes:
+      - .:/app
+      - node-modules:/app/node_modules
+    depends_on:
+      postgres:
+        condition: service_healthy
+      deps:
+        condition: service_completed_successfully
+    command: ['bun', 'run', '--filter', '@schediochron/sql', 'migrate']
+
+  api:
+    image: oven/bun:1.3
+    working_dir: /app
+    environment:
+      PORT: '3000'
+      DATABASE_URL: ${DATABASE_URL:-postgres://schediochron:schediochron@postgres:5432/schediochron}
+    ports:
+      - '${API_PORT:-3000}:3000'
+    volumes:
+      - .:/app
+      - node-modules:/app/node_modules
+    depends_on:
+      postgres:
+        condition: service_healthy
+      migrate:
+        condition: service_completed_successfully
+    command: ['bun', 'run', 'dev:api']
+
+  web:
+    image: oven/bun:1.3
+    working_dir: /app
+    environment:
+      FONTAWESOME_TOKEN: ${FONTAWESOME_TOKEN:-}
+    ports:
+      - '${WEB_PORT:-4200}:4200'
+    volumes:
+      - .:/app
+      - node-modules:/app/node_modules
+    depends_on:
+      deps:
+        condition: service_completed_successfully
+    command: ['bun', 'run', 'dev']
+
+volumes:
+  postgres-data:
+  node-modules:


### PR DESCRIPTION
Closes #36. Stacked on #25 (runs its migrations).

Brings the full local stack up with one command:

```bash
cp .env.example .env   # set FONTAWESOME_TOKEN
docker compose up
```

## Services (`docker-compose.yml`)
- **postgres** (`postgres:16-alpine`) with a healthcheck and a persistent volume.
- **deps** — one-shot `bun install` into a shared `node_modules` named volume, so the long-running services don't each race to install.
- **migrate** — one-shot; waits for a healthy postgres, runs `@schediochron/sql migrate`, exits. This is how **migrations run automatically on startup**.
- **api** — `bun run dev:api` on :3000; waits for postgres healthy + migrate completed.
- **web** — `bun run dev` (React dev server) on :4200.

The repo is bind-mounted for hot reload; `node_modules` lives in a named volume so the container's Linux binaries never clash with the host's macOS ones.

## Config
- `.env.example` documents all defaults (`POSTGRES_*`, `DATABASE_URL`, `API_PORT`, `WEB_PORT`, `FONTAWESOME_TOKEN`). `.env` is now git-ignored.
- README gains a "Full stack with Docker Compose" section.

## Verification
- Compose file validates (`docker-compose config` lists all five services and resolves the `depends_on` conditions) ✅
- Prettier-clean; no code changes so build/typecheck/lint unaffected.

⚠️ **The "dev server actually renders in the browser" criterion (#123) is NOT verified here** — this environment has no working Docker daemon. A reviewer must run `docker compose up` and confirm http://localhost:4200 renders a real page (not a blank one) and the API answers on :3000. The `FONTAWESOME_TOKEN` must be set for the web install to succeed (see CONTRIBUTING.md).

🤖 Generated with [Claude Code](https://claude.com/claude-code)