### PR TITLE
feature(28) + [sql] implement Team repository

### DIFF
--- a/libs/sql/src/index.ts
+++ b/libs/sql/src/index.ts
@@ -6,6 +6,8 @@
 
 export { createSqlClient } from './db.js';
 
+export { TeamSqlRepository, LastAdminError } from './team-repository.js';
+
 export type { Migration, MigrationStatus } from './migrate.js';
 export {
   discoverMigrations,

--- a/libs/sql/src/team-repository.spec.ts
+++ b/libs/sql/src/team-repository.spec.ts
@@ -1,0 +1,260 @@
+import { afterAll, beforeAll, describe, expect, it } from 'bun:test';
+import type { SQL } from 'bun';
+import type { Team } from '@schediochron/core';
+import { createSqlClient } from './db.js';
+import { migrateUp } from './migrate.js';
+import {
+  LastAdminError,
+  TeamSqlRepository,
+  mapTeamRow,
+} from './team-repository.js';
+
+// --- Pure logic: runs everywhere, no database ---------------------------------
+
+describe('mapTeamRow', () => {
+  it('assembles memberIds from all rows and adminIds from the admin rows', () => {
+    const team = mapTeamRow({
+      id: '11111111-1111-4111-8111-111111111111',
+      name: 'Platform',
+      created_at: new Date('2026-01-01T00:00:00.000Z'),
+      updated_at: new Date('2026-01-02T00:00:00.000Z'),
+      members: [
+        { userId: 'aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa', isAdmin: true },
+        { userId: 'bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb', isAdmin: false },
+        { userId: 'cccccccc-cccc-4ccc-8ccc-cccccccccccc', isAdmin: true },
+      ],
+    });
+
+    expect(team.memberIds).toEqual([
+      'aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa',
+      'bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb',
+      'cccccccc-cccc-4ccc-8ccc-cccccccccccc',
+    ]);
+    expect(team.adminIds).toEqual([
+      'aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa',
+      'cccccccc-cccc-4ccc-8ccc-cccccccccccc',
+    ]);
+  });
+
+  it('keeps adminIds a subset of memberIds', () => {
+    const team = mapTeamRow({
+      id: '11111111-1111-4111-8111-111111111111',
+      name: 'Platform',
+      created_at: new Date(),
+      updated_at: new Date(),
+      members: [
+        { userId: 'aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa', isAdmin: true },
+        { userId: 'bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb', isAdmin: false },
+      ],
+    });
+    const members = new Set(team.memberIds);
+    expect(team.adminIds.every((id) => members.has(id))).toBe(true);
+  });
+
+  it('emits ISO 8601 UTC timestamps for Date and string inputs alike', () => {
+    const fromDate = mapTeamRow({
+      id: '11111111-1111-4111-8111-111111111111',
+      name: 'T',
+      created_at: new Date('2026-03-04T05:06:07.000Z'),
+      updated_at: '2026-03-04T05:06:08.000Z',
+      members: [],
+    });
+    expect(fromDate.createdAt).toBe('2026-03-04T05:06:07.000Z');
+    expect(fromDate.updatedAt).toBe('2026-03-04T05:06:08.000Z');
+  });
+});
+
+describe('LastAdminError', () => {
+  it('carries the team and user it refused to leave unadministered', () => {
+    const err = new LastAdminError('team-1', 'user-1');
+    expect(err).toBeInstanceOf(Error);
+    expect(err.name).toBe('LastAdminError');
+    expect(err.teamId).toBe('team-1');
+    expect(err.userId).toBe('user-1');
+  });
+});
+
+// --- Database-backed: skipped without a live PostgreSQL (no Docker here) -------
+
+describe.skipIf(!process.env.DATABASE_URL)(
+  'TeamSqlRepository (postgres)',
+  () => {
+    let sql: SQL;
+    let repo: TeamSqlRepository;
+
+    // Four users the tests draw members from; team_members.user_id is a FK to users.
+    const [alice, bob, carol, dave] = [
+      crypto.randomUUID(),
+      crypto.randomUUID(),
+      crypto.randomUUID(),
+      crypto.randomUUID(),
+    ];
+    const userIds = [alice, bob, carol, dave];
+    const createdTeamIds: string[] = [];
+
+    const isoNow = () => new Date().toISOString();
+
+    function newTeam(overrides: Partial<Team> = {}): Team {
+      const id = crypto.randomUUID();
+      createdTeamIds.push(id);
+      return {
+        id,
+        name: 'Team',
+        adminIds: [alice],
+        memberIds: [alice],
+        createdAt: isoNow(),
+        updatedAt: isoNow(),
+        ...overrides,
+      };
+    }
+
+    beforeAll(async () => {
+      sql = createSqlClient();
+      await migrateUp(sql);
+      for (const id of userIds) {
+        await sql`
+        INSERT INTO users (id, username, role)
+        VALUES (${id}, ${'u' + id.slice(0, 8)}, 'member')
+        ON CONFLICT (id) DO NOTHING`;
+      }
+      repo = new TeamSqlRepository(sql);
+    });
+
+    afterAll(async () => {
+      for (const id of createdTeamIds) {
+        await sql`DELETE FROM teams WHERE id = ${id}`;
+      }
+      for (const id of userIds) {
+        await sql`DELETE FROM users WHERE id = ${id}`;
+      }
+      await sql.close();
+    });
+
+    it('round-trips create → findById, assembling admins and members', async () => {
+      const team = newTeam({
+        name: '  Platform  ',
+        adminIds: [alice],
+        memberIds: [alice, bob],
+      });
+      const created = await repo.create(team);
+      expect(created.name).toBe('Platform'); // trimmed by teamSchema
+      expect(new Set(created.memberIds)).toEqual(new Set([alice, bob]));
+      expect(created.adminIds).toEqual([alice]);
+      expect(created.createdAt).toMatch(/Z$/);
+
+      const found = await repo.findById(team.id);
+      expect(found).not.toBeNull();
+      expect(new Set(found?.memberIds)).toEqual(new Set([alice, bob]));
+      expect(found?.adminIds).toEqual([alice]);
+    });
+
+    it('findById returns null for an unknown id', async () => {
+      expect(await repo.findById(crypto.randomUUID())).toBeNull();
+    });
+
+    it('findByUserId returns every team the user participates in', async () => {
+      const t1 = await repo.create(
+        newTeam({ adminIds: [carol], memberIds: [carol] }),
+      );
+      const t2 = await repo.create(
+        newTeam({ adminIds: [dave], memberIds: [dave, carol] }),
+      );
+      const teams = await repo.findByUserId(carol);
+      const ids = teams.map((t) => t.id);
+      expect(ids).toContain(t1.id);
+      expect(ids).toContain(t2.id);
+    });
+
+    it('addMember adds a plain member and is idempotent', async () => {
+      const team = await repo.create(
+        newTeam({ adminIds: [alice], memberIds: [alice] }),
+      );
+      const after = await repo.addMember(team.id, bob);
+      expect(new Set(after.memberIds)).toEqual(new Set([alice, bob]));
+      expect(after.adminIds).toEqual([alice]);
+
+      const again = await repo.addMember(team.id, bob); // no-op
+      expect(new Set(again.memberIds)).toEqual(new Set([alice, bob]));
+    });
+
+    it('assignAdmin promotes an existing member and admits an absent one', async () => {
+      const team = await repo.create(
+        newTeam({ adminIds: [alice], memberIds: [alice, bob] }),
+      );
+      const promoted = await repo.assignAdmin(team.id, bob);
+      expect(new Set(promoted.adminIds)).toEqual(new Set([alice, bob]));
+
+      const admittedAndPromoted = await repo.assignAdmin(team.id, carol);
+      expect(new Set(admittedAndPromoted.memberIds)).toEqual(
+        new Set([alice, bob, carol]),
+      );
+      expect(new Set(admittedAndPromoted.adminIds)).toEqual(
+        new Set([alice, bob, carol]),
+      );
+    });
+
+    it('removeAdmin demotes an admin but leaves them a member', async () => {
+      const team = await repo.create(
+        newTeam({ adminIds: [alice, bob], memberIds: [alice, bob] }),
+      );
+      const after = await repo.removeAdmin(team.id, bob);
+      expect(after.adminIds).toEqual([alice]);
+      expect(new Set(after.memberIds)).toEqual(new Set([alice, bob]));
+    });
+
+    it('removeMember drops a user from both arrays', async () => {
+      const team = await repo.create(
+        newTeam({ adminIds: [alice, bob], memberIds: [alice, bob] }),
+      );
+      const after = await repo.removeMember(team.id, bob);
+      expect(after.memberIds).toEqual([alice]);
+      expect(after.adminIds).toEqual([alice]);
+    });
+
+    it('rejects removeAdmin of the last admin', async () => {
+      const team = await repo.create(
+        newTeam({ adminIds: [alice], memberIds: [alice] }),
+      );
+      await expect(repo.removeAdmin(team.id, alice)).rejects.toBeInstanceOf(
+        LastAdminError,
+      );
+      // Unchanged: still an admin.
+      const still = await repo.findById(team.id);
+      expect(still?.adminIds).toEqual([alice]);
+    });
+
+    it('rejects removeMember that would remove the last admin', async () => {
+      const team = await repo.create(
+        newTeam({ adminIds: [alice], memberIds: [alice, bob] }),
+      );
+      await expect(repo.removeMember(team.id, alice)).rejects.toBeInstanceOf(
+        LastAdminError,
+      );
+      const still = await repo.findById(team.id);
+      expect(new Set(still?.memberIds)).toEqual(new Set([alice, bob]));
+    });
+
+    it('update replaces name and membership atomically', async () => {
+      const team = await repo.create(
+        newTeam({ name: 'Old', adminIds: [alice], memberIds: [alice] }),
+      );
+      const next: Team = {
+        ...team,
+        name: 'New',
+        adminIds: [alice, bob],
+        memberIds: [alice, bob, carol],
+      };
+      const updated = await repo.update(next);
+      expect(updated.name).toBe('New');
+      expect(new Set(updated.adminIds)).toEqual(new Set([alice, bob]));
+      expect(new Set(updated.memberIds)).toEqual(new Set([alice, bob, carol]));
+    });
+
+    it('delete removes the team and its membership', async () => {
+      const team = await repo.create(newTeam());
+      await repo.delete(team.id);
+      expect(await repo.findById(team.id)).toBeNull();
+      await repo.delete(team.id); // no-op on unknown id
+    });
+  },
+);

--- a/libs/sql/src/team-repository.ts
+++ b/libs/sql/src/team-repository.ts
@@ -1,0 +1,272 @@
+import type { SQL } from 'bun';
+import { type Team, type TeamRepository, teamSchema } from '@schediochron/core';
+
+/**
+ * Thrown when a membership mutation would leave a team with no admin. The API
+ * layer maps this to 409 Conflict. ADR-004's "at least one admin" invariant is
+ * not expressible as a row constraint, so it is enforced here, inside the
+ * mutations, atomically with the write it guards.
+ */
+export class LastAdminError extends Error {
+  readonly teamId: string;
+  readonly userId: string;
+
+  constructor(teamId: string, userId: string) {
+    super(
+      `Cannot remove the last admin (user ${userId}) of team ${teamId} — a team must always have at least one admin.`,
+    );
+    this.name = 'LastAdminError';
+    this.teamId = teamId;
+    this.userId = userId;
+  }
+}
+
+/**
+ * A single row of the `team_members` join table as it appears inside the
+ * aggregated team read (see {@link TEAM_SELECT}).
+ */
+interface MemberJson {
+  userId: string;
+  isAdmin: boolean;
+}
+
+/** A `teams` row joined with its aggregated membership. */
+interface TeamRow {
+  id: string;
+  name: string;
+  created_at: Date | string;
+  updated_at: Date | string;
+  members: MemberJson[];
+}
+
+/**
+ * Any tagged-template SQL executor — the top-level client or a transaction
+ * handle (`TransactionSQL extends SQL`). Reads and writes take one so the same
+ * helper runs both standalone and inside `sql.begin`.
+ */
+type Executor = SQL;
+
+/**
+ * The read shape for a team: the scalar columns plus its membership aggregated
+ * into a single JSON array, so one row fully describes one team. `is_admin`
+ * marks the admins among the members, exactly as the join table stores it.
+ *
+ * TODO(#…): extract shared row mapping once a second repository needs it.
+ */
+const TEAM_SELECT = `
+  SELECT
+    t.id,
+    t.name,
+    t.created_at,
+    t.updated_at,
+    COALESCE(
+      (
+        SELECT json_agg(
+                 json_build_object('userId', tm.user_id, 'isAdmin', tm.is_admin)
+                 ORDER BY tm.created_at, tm.user_id
+               )
+        FROM team_members tm
+        WHERE tm.team_id = t.id
+      ),
+      '[]'::json
+    ) AS members
+  FROM teams t`;
+
+/** Normalises a `timestamptz` (Bun hands these back as `Date`) to ISO 8601 UTC. */
+function toIso(value: Date | string): string {
+  return (value instanceof Date ? value : new Date(value)).toISOString();
+}
+
+/**
+ * Assembles the two-array {@link Team} model from a join-table read. `memberIds`
+ * is every participant; `adminIds` is the admins among them — so `adminIds ⊆
+ * memberIds` holds by construction, never by a separate check.
+ *
+ * Exported for unit testing; not part of the package's public API.
+ */
+export function mapTeamRow(row: TeamRow): Team {
+  const members = row.members ?? [];
+  return {
+    id: row.id,
+    name: row.name,
+    memberIds: members.map((m) => m.userId),
+    adminIds: members.filter((m) => m.isAdmin).map((m) => m.userId),
+    createdAt: toIso(row.created_at),
+    updatedAt: toIso(row.updated_at),
+  };
+}
+
+/**
+ * PostgreSQL-backed {@link TeamRepository} over the `teams` / `team_members`
+ * join table.
+ *
+ * The `Team` model's `adminIds`/`memberIds` are assembled from join rows on read
+ * and decomposed into them on write. Every membership mutation runs in a single
+ * transaction so ADR-004's invariants — `adminIds ⊆ memberIds`, at least one
+ * admin — hold atomically; none is a read-modify-write of the whole team.
+ */
+export class TeamSqlRepository implements TeamRepository {
+  constructor(private readonly sql: SQL) {}
+
+  async findById(id: string): Promise<Team | null> {
+    return this.load(this.sql, id);
+  }
+
+  async findAll(): Promise<Team[]> {
+    const rows = await this.sql<
+      TeamRow[]
+    >`${this.sql.unsafe(TEAM_SELECT)} ORDER BY t.created_at, t.id`;
+    return rows.map(mapTeamRow);
+  }
+
+  async findByUserId(userId: string): Promise<Team[]> {
+    const rows = await this.sql<TeamRow[]>`
+      ${this.sql.unsafe(TEAM_SELECT)}
+      WHERE EXISTS (
+        SELECT 1 FROM team_members m
+        WHERE m.team_id = t.id AND m.user_id = ${userId}
+      )
+      ORDER BY t.created_at, t.id`;
+    return rows.map(mapTeamRow);
+  }
+
+  async create(team: Team): Promise<Team> {
+    // teamSchema enforces adminIds non-empty and adminIds ⊆ memberIds; fail loud.
+    const valid = teamSchema.parse(team);
+    const admins = new Set(valid.adminIds);
+    return this.sql.begin(async (tx) => {
+      await tx`INSERT INTO teams (id, name) VALUES (${valid.id}, ${valid.name})`;
+      for (const userId of valid.memberIds) {
+        await tx`
+          INSERT INTO team_members (team_id, user_id, is_admin)
+          VALUES (${valid.id}, ${userId}, ${admins.has(userId)})`;
+      }
+      return this.require(tx, valid.id);
+    });
+  }
+
+  /**
+   * Authoritative replace of a team's name and full membership. Validated by
+   * teamSchema (so the invariants hold) and applied in one transaction, which is
+   * what makes a whole-team write safe here where a piecemeal one would not be.
+   */
+  async update(team: Team): Promise<Team> {
+    const valid = teamSchema.parse(team);
+    const admins = new Set(valid.adminIds);
+    return this.sql.begin(async (tx) => {
+      const updated = await tx`
+        UPDATE teams SET name = ${valid.name}, updated_at = now()
+        WHERE id = ${valid.id} RETURNING id`;
+      if (updated.length === 0) throw new Error(`Team ${valid.id} not found.`);
+      await tx`DELETE FROM team_members WHERE team_id = ${valid.id}`;
+      for (const userId of valid.memberIds) {
+        await tx`
+          INSERT INTO team_members (team_id, user_id, is_admin)
+          VALUES (${valid.id}, ${userId}, ${admins.has(userId)})`;
+      }
+      return this.require(tx, valid.id);
+    });
+  }
+
+  /** Deleting an unknown id is a no-op; `ON DELETE CASCADE` clears membership. */
+  async delete(id: string): Promise<void> {
+    await this.sql`DELETE FROM teams WHERE id = ${id}`;
+  }
+
+  async addMember(teamId: string, userId: string): Promise<Team> {
+    return this.sql.begin(async (tx) => {
+      await this.assertTeamExists(tx, teamId);
+      const inserted = await tx`
+        INSERT INTO team_members (team_id, user_id, is_admin)
+        VALUES (${teamId}, ${userId}, false)
+        ON CONFLICT (team_id, user_id) DO NOTHING
+        RETURNING user_id`;
+      if (inserted.length > 0) await this.touch(tx, teamId);
+      return this.require(tx, teamId);
+    });
+  }
+
+  async removeMember(teamId: string, userId: string): Promise<Team> {
+    return this.sql.begin(async (tx) => {
+      await this.assertTeamExists(tx, teamId);
+      const adminIds = await this.adminIds(tx, teamId);
+      const isAdmin = adminIds.includes(userId);
+      if (isAdmin && adminIds.length === 1) {
+        throw new LastAdminError(teamId, userId);
+      }
+      const deleted = await tx`
+        DELETE FROM team_members
+        WHERE team_id = ${teamId} AND user_id = ${userId}
+        RETURNING user_id`;
+      if (deleted.length > 0) await this.touch(tx, teamId);
+      return this.require(tx, teamId);
+    });
+  }
+
+  async assignAdmin(teamId: string, userId: string): Promise<Team> {
+    return this.sql.begin(async (tx) => {
+      await this.assertTeamExists(tx, teamId);
+      // Insert the membership if absent, promote it if present — both or neither,
+      // in one statement. The DO UPDATE ... WHERE skips a no-op re-promotion so
+      // updated_at only moves when something actually changed.
+      const changed = await tx`
+        INSERT INTO team_members (team_id, user_id, is_admin)
+        VALUES (${teamId}, ${userId}, true)
+        ON CONFLICT (team_id, user_id) DO UPDATE SET is_admin = true
+        WHERE team_members.is_admin IS DISTINCT FROM true
+        RETURNING user_id`;
+      if (changed.length > 0) await this.touch(tx, teamId);
+      return this.require(tx, teamId);
+    });
+  }
+
+  async removeAdmin(teamId: string, userId: string): Promise<Team> {
+    return this.sql.begin(async (tx) => {
+      await this.assertTeamExists(tx, teamId);
+      const adminIds = await this.adminIds(tx, teamId);
+      const isAdmin = adminIds.includes(userId);
+      if (isAdmin && adminIds.length === 1) {
+        throw new LastAdminError(teamId, userId);
+      }
+      if (isAdmin) {
+        await tx`
+          UPDATE team_members SET is_admin = false
+          WHERE team_id = ${teamId} AND user_id = ${userId}`;
+        await this.touch(tx, teamId);
+      }
+      return this.require(tx, teamId);
+    });
+  }
+
+  private async load(exec: Executor, id: string): Promise<Team | null> {
+    const rows = await exec<TeamRow[]>`
+      ${exec.unsafe(TEAM_SELECT)} WHERE t.id = ${id}`;
+    return rows.length > 0 ? mapTeamRow(rows[0]) : null;
+  }
+
+  /** Loads a team that must exist (the mutation just wrote it). */
+  private async require(exec: Executor, id: string): Promise<Team> {
+    const team = await this.load(exec, id);
+    if (!team) throw new Error(`Team ${id} not found.`);
+    return team;
+  }
+
+  private async assertTeamExists(
+    exec: Executor,
+    teamId: string,
+  ): Promise<void> {
+    const rows = await exec`SELECT 1 FROM teams WHERE id = ${teamId}`;
+    if (rows.length === 0) throw new Error(`Team ${teamId} not found.`);
+  }
+
+  private async adminIds(exec: Executor, teamId: string): Promise<string[]> {
+    const rows = await exec<{ user_id: string }[]>`
+      SELECT user_id FROM team_members
+      WHERE team_id = ${teamId} AND is_admin`;
+    return rows.map((r) => r.user_id);
+  }
+
+  private async touch(exec: Executor, teamId: string): Promise<void> {
+    await exec`UPDATE teams SET updated_at = now() WHERE id = ${teamId}`;
+  }
+}


### PR DESCRIPTION
Closes #28.

Stacked on #25 (schema and migrations) — base this PR's diff against `feature/25-define-db-schema-and-migrations`.

## What

`TeamSqlRepository` in `@schediochron/sql`: the PostgreSQL implementation of `TeamRepository` from `@schediochron/core`, over the `teams` / `team_members` join table.

### Join-table assembly
The `Team` model exposes `adminIds: string[]` and `memberIds: string[]`, but storage is `team_members(team_id, user_id, is_admin)`. On read, a single query aggregates each team's membership into a JSON array; `memberIds` is every participant and `adminIds` the admins among them, so `adminIds ⊆ memberIds` holds by construction. On write, the arrays are decomposed back into join rows (`is_admin = adminIds.includes(userId)`).

### Atomic invariant enforcement
Every membership mutation runs in one `sql.begin` transaction rather than a read-modify-write of the whole team:
- `addMember` — insert `is_admin=false`, `ON CONFLICT DO NOTHING` (idempotent).
- `removeMember` — delete the row; **rejects removing the last admin**.
- `assignAdmin` — upsert the membership with `is_admin=true` (both or neither).
- `removeAdmin` — clear `is_admin`, leaving membership; **rejects the last admin**.

ADR-004's "at least one admin" is not a row constraint, so it is enforced here. The two last-admin rejections throw an exported, typed `LastAdminError` (teamId + userId) the API layer can map to 409. `create`/`update` write the whole membership set atomically and validate via `teamSchema` (non-empty admins, subset). `teams.updated_at` is refreshed only when membership actually changes.

## Tests

Pure `mapTeamRow` / `LastAdminError` logic runs unconditionally. DB-backed round-trip, `findByUserId`, add/remove member, assign/remove admin, and last-admin-rejection tests are gated with `describe.skipIf(!process.env.DATABASE_URL)` — **there is no live PostgreSQL/Docker in this environment**, so they skip here and run wherever `DATABASE_URL` is set.

Verified: build, typecheck, lint, and `@schediochron/sql` tests all pass (16 pass, 13 skip, 0 fail).

🤖 Generated with [Claude Code](https://claude.com/claude-code)