### PR TITLE
feature(71) + [api] contract-driven request validation and error handling

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -47,9 +47,11 @@
       "name": "@schediochron/api",
       "version": "0.2.0",
       "dependencies": {
+        "@hono/zod-openapi": "^0.19.10",
         "@schediochron/core": "workspace:^",
         "hono": "^4.12.0",
         "tslib": "^2.3.0",
+        "zod": "^3.24.0",
       },
     },
     "libs/core": {
@@ -88,6 +90,8 @@
     },
   },
   "packages": {
+    "@asteasolutions/zod-to-openapi": ["@asteasolutions/zod-to-openapi@7.3.4", "", { "dependencies": { "openapi3-ts": "^4.1.2" }, "peerDependencies": { "zod": "^3.20.2" } }, "sha512-/2rThQ5zPi9OzVwes6U7lK1+Yvug0iXu25olp7S0XsYmOqnyMfxH7gdSQjn/+DSOHRg7wnotwGJSyL+fBKdnEA=="],
+
     "@babel/code-frame": ["@babel/code-frame@7.29.0", "", { "dependencies": { "@babel/helper-validator-identifier": "^7.28.5", "js-tokens": "^4.0.0", "picocolors": "^1.1.1" } }, "sha512-9NhCeYjq9+3uxgdtp20LSiJXJvN0FeCtNGpJxuMFZ1Kv3cWUNb6DOhJwUvcVCzKGR66cw4njwM6hrJLqgOwbcw=="],
 
     "@babel/compat-data": ["@babel/compat-data@7.29.0", "", {}, "sha512-T1NCJqT/j9+cn8fvkt7jtwbLBfLC/1y1c7NtCeXFRgzGTsafi68MRv8yzkYSapBnFA6L3U2VSc02ciDzoAJhJg=="],
@@ -149,6 +153,10 @@
     "@fortawesome/react-fontawesome": ["@fortawesome/react-fontawesome@3.4.0", "", { "peerDependencies": { "@fortawesome/fontawesome-svg-core": "~6 || ~7", "react": "^18.0.0 || ^19.0.0" } }, "sha512-EgY5CXzzm6WGnUB40j9qNajYmoJHC8TUV/rvpcmHUoPZmQyRlh8WuRaxaerjMq61NZAz0vS+MOoJaPbZWRDibw=="],
 
     "@happy-dom/global-registrator": ["@happy-dom/global-registrator@20.10.6", "", { "dependencies": { "@types/node": ">=20.0.0", "happy-dom": "^20.10.6" } }, "sha512-Nu/IjRkkNxmeG2ywWsyJSO4d1BrWTqVzxCPL+gXj0b97klhmjd6wLzt6Bx/laNpkZ3WLW7zNCqmtMIbIlahqug=="],
+
+    "@hono/zod-openapi": ["@hono/zod-openapi@0.19.10", "", { "dependencies": { "@asteasolutions/zod-to-openapi": "^7.3.0", "@hono/zod-validator": "^0.7.1", "openapi3-ts": "^4.5.0" }, "peerDependencies": { "hono": ">=4.3.6", "zod": ">=3.0.0" } }, "sha512-dpoS6DenvoJyvxtQ7Kd633FRZ/Qf74+4+o9s+zZI8pEqnbjdF/DtxIib08WDpCaWabMEJOL5TXpMgNEZvb7hpA=="],
+
+    "@hono/zod-validator": ["@hono/zod-validator@0.7.6", "", { "peerDependencies": { "hono": ">=3.9.0", "zod": "^3.25.0 || ^4.0.0" } }, "sha512-Io1B6d011Gj1KknV4rXYz4le5+5EubcWEU/speUjuw9XMMIaP3n78yXLhjd2A3PXaXaUwEAluOiAyLqhBEJgsw=="],
 
     "@humanfs/core": ["@humanfs/core@0.19.1", "", {}, "sha512-5DyQ4+1JEUzejeK1JGICcideyfUbGixgS9jNgex5nqkW+cY7WZhxBigmieN5Qnw9ZosSNVC9KQKyb+GUaGyKUA=="],
 
@@ -562,6 +570,8 @@
 
     "object.values": ["object.values@1.2.1", "", { "dependencies": { "call-bind": "^1.0.8", "call-bound": "^1.0.3", "define-properties": "^1.2.1", "es-object-atoms": "^1.0.0" } }, "sha512-gXah6aZrcUxjWg2zR2MwouP2eHlCBzdV4pygudehaKXSGW4v2AsRQUK+lwwXhii6KFZcunEnmSUoYp5CXibxtA=="],
 
+    "openapi3-ts": ["openapi3-ts@4.6.0", "", { "dependencies": { "yaml": "^2.9.0" } }, "sha512-a4sfn6L2sIShhtzJqmjGrARvxAW/3F2BJDdyRVvNF9VhAsZSh5hSyI3a9TNvmzBxXmq66nY5LNT5bQcBxYAZZg=="],
+
     "optionator": ["optionator@0.9.4", "", { "dependencies": { "deep-is": "^0.1.3", "fast-levenshtein": "^2.0.6", "levn": "^0.4.1", "prelude-ls": "^1.2.1", "type-check": "^0.4.0", "word-wrap": "^1.2.5" } }, "sha512-6IpQ7mKUxRcZNLIObR0hz7lxsapSSIYNZJwXPGeF0mTVqGKFIXj1DQcMoT22S3ROcLyY/rz0PWaWZ9ayWmad9g=="],
 
     "own-keys": ["own-keys@1.0.1", "", { "dependencies": { "get-intrinsic": "^1.2.6", "object-keys": "^1.1.1", "safe-push-apply": "^1.0.0" } }, "sha512-qFOyK5PjiWZd+QQIh+1jhdb9LpxTF0qs7Pm8o5QHYZ0M3vKqSqzsZaEB6oWlxZ+q2sJBMI/Ktgd2N5ZwQoRHfg=="],
@@ -707,6 +717,8 @@
     "ws": ["ws@8.21.1", "", { "peerDependencies": { "bufferutil": "^4.0.1", "utf-8-validate": ">=5.0.2" }, "optionalPeers": ["bufferutil", "utf-8-validate"] }, "sha512-+0NTnW77fFN/DjQi6k/Sq/Yvk4Sgajw7urW8V+asjXnRgDs9gyGkdb7EzgfhA4goXsRIZKE28fzIXBHEzhuiWw=="],
 
     "yallist": ["yallist@3.1.1", "", {}, "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g=="],
+
+    "yaml": ["yaml@2.9.0", "", { "bin": { "yaml": "bin.mjs" } }, "sha512-2AvhNX3mb8zd6Zy7INTtSpl1F15HW6Wnqj0srWlkKLcpYl/gMIMJiyuGq2KeI2YFxUPjdlB+3Lc10seMLtL4cA=="],
 
     "yocto-queue": ["yocto-queue@0.1.0", "", {}, "sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q=="],
 

--- a/libs/api/package.json
+++ b/libs/api/package.json
@@ -19,8 +19,10 @@
     "test:watch": "bun test --watch"
   },
   "dependencies": {
+    "@hono/zod-openapi": "^0.19.10",
     "@schediochron/core": "workspace:^",
     "hono": "^4.12.0",
-    "tslib": "^2.3.0"
+    "tslib": "^2.3.0",
+    "zod": "^3.24.0"
   }
 }

--- a/libs/api/src/app.ts
+++ b/libs/api/src/app.ts
@@ -1,5 +1,5 @@
-import { Hono } from 'hono';
 import type { ErrorResponse } from '@schediochron/core';
+import { createRouter } from './http.js';
 import { authRoutes } from './routes/auth.js';
 import { reportRoutes } from './routes/reports.js';
 import { teamRoutes } from './routes/teams.js';
@@ -11,11 +11,12 @@ import { userRoutes } from './routes/users.js';
  * Web-standard `Request`/`Response` (see ADR-006). Runtime entrypoints such as
  * `main.ts` adapt `app.fetch` to a concrete server.
  *
- * Routes mirror `openapi.yaml` and currently return stub payloads (#83).
- * Authentication and request validation land in Phase 2 (#71), so for now every
- * endpoint answers as though the caller were authorised.
+ * Built as an `OpenAPIHono` via {@link createRouter} so request validation
+ * derives from the contract Zod schemas and rejects malformed input with the
+ * `ErrorResponse` envelope (#71). Routes mirror `openapi.yaml` and currently
+ * return stub payloads (#83); authentication lands with the endpoints.
  */
-export const app = new Hono();
+export const app = createRouter();
 
 app.get('/health', (c) =>
   c.json({ status: 'ok', timestamp: new Date().toISOString() }),

--- a/libs/api/src/http.spec.ts
+++ b/libs/api/src/http.spec.ts
@@ -1,0 +1,170 @@
+import { describe, expect, it } from 'bun:test';
+import { createRoute, z } from '@hono/zod-openapi';
+import { Hono } from 'hono';
+import {
+  badRequest,
+  conflict,
+  createRouter,
+  forbidden,
+  formatZodIssues,
+  notFound,
+  unauthorized,
+  type ValidationIssue,
+} from './http.js';
+import { createTeamRequestSchema, hoursReportQuerySchema } from './schemas.js';
+
+type Envelope = { error: string; details?: unknown };
+
+// --- Typed error helpers ---------------------------------------------------
+
+const helpers = [
+  { name: 'badRequest', status: 400, fn: badRequest },
+  { name: 'unauthorized', status: 401, fn: unauthorized },
+  { name: 'forbidden', status: 403, fn: forbidden },
+  { name: 'notFound', status: 404, fn: notFound },
+  { name: 'conflict', status: 409, fn: conflict },
+] as const;
+
+const helperApp = new Hono();
+for (const { name, fn } of helpers) {
+  helperApp.get(`/${name}`, (c) => fn(c));
+  helperApp.get(`/${name}-custom`, (c) => fn(c, 'custom message', { field: 'x' }));
+}
+
+describe('error helpers', () => {
+  for (const { name, status } of helpers) {
+    it(`${name} answers ${status} in the ErrorResponse envelope`, async () => {
+      const res = await helperApp.request(`/${name}`);
+
+      expect(res.status).toBe(status);
+      expect(res.headers.get('content-type')).toContain('application/json');
+
+      const body = (await res.json()) as Envelope;
+      expect(typeof body.error).toBe('string');
+      // `details` is omitted entirely when not supplied.
+      expect('details' in body).toBe(false);
+    });
+
+    it(`${name} carries a custom message and details`, async () => {
+      const res = await helperApp.request(`/${name}-custom`);
+
+      expect(res.status).toBe(status);
+      const body = (await res.json()) as Envelope;
+      expect(body.error).toBe('custom message');
+      expect(body.details).toEqual({ field: 'x' });
+    });
+  }
+});
+
+// --- Zod issue formatting --------------------------------------------------
+
+describe('formatZodIssues', () => {
+  it('reduces each issue to a path and a schema-authored message only', () => {
+    const result = createTeamRequestSchema.safeParse({ name: '' });
+    expect(result.success).toBe(false);
+    if (result.success) return;
+
+    const issues = formatZodIssues(result.error);
+    expect(issues.length).toBeGreaterThan(0);
+    for (const issue of issues) {
+      expect(Object.keys(issue).sort()).toEqual(['message', 'path']);
+      expect(typeof issue.path).toBe('string');
+      expect(typeof issue.message).toBe('string');
+    }
+    expect(issues[0]?.path).toBe('name');
+  });
+});
+
+// --- Request validation wired through the shared hook ----------------------
+
+const okSchema = z.object({ ok: z.boolean() });
+
+const teamRoute = createRoute({
+  method: 'post',
+  path: '/teams',
+  request: {
+    body: { content: { 'application/json': { schema: createTeamRequestSchema } } },
+  },
+  responses: {
+    201: { description: 'created', content: { 'application/json': { schema: okSchema } } },
+  },
+});
+
+const reportRoute = createRoute({
+  method: 'get',
+  path: '/reports',
+  request: { query: hoursReportQuerySchema },
+  responses: {
+    200: { description: 'ok', content: { 'application/json': { schema: okSchema } } },
+  },
+});
+
+const validated = createRouter();
+validated.openapi(teamRoute, (c) => c.json({ ok: true }, 201));
+validated.openapi(reportRoute, (c) => c.json({ ok: true }, 200));
+
+const postTeam = (body: unknown) =>
+  validated.request('/teams', {
+    method: 'POST',
+    headers: { 'content-type': 'application/json' },
+    body: JSON.stringify(body),
+  });
+
+describe('request validation via the shared hook', () => {
+  it('rejects a malformed body with 400 and the ErrorResponse envelope', async () => {
+    const res = await postTeam({ name: '' });
+
+    expect(res.status).toBe(400);
+    expect(res.headers.get('content-type')).toContain('application/json');
+
+    const body = (await res.json()) as { error: string; details: ValidationIssue[] };
+    expect(body.error).toBe('Validation failed');
+    expect(Array.isArray(body.details)).toBe(true);
+    expect(body.details.length).toBeGreaterThan(0);
+    for (const issue of body.details) {
+      expect(Object.keys(issue).sort()).toEqual(['message', 'path']);
+    }
+  });
+
+  it('reports a missing required field as a field-level detail', async () => {
+    const res = await postTeam({});
+    expect(res.status).toBe(400);
+
+    const body = (await res.json()) as { details: ValidationIssue[] };
+    expect(body.details.some((issue) => issue.path === 'name')).toBe(true);
+  });
+
+  it('never leaks internals (stack, driver, SQL) into details', async () => {
+    const res = await postTeam({ name: 123 });
+    const raw = JSON.stringify(await res.json()).toLowerCase();
+
+    for (const leak of [
+      'stack',
+      'zoderror',
+      'sql',
+      'select ',
+      'at object',
+      'node_modules',
+      '.ts:',
+    ]) {
+      expect(raw).not.toContain(leak);
+    }
+  });
+
+  it('validates query parameters against the contract too', async () => {
+    const res = await validated.request('/reports?range=year');
+    expect(res.status).toBe(400);
+
+    const body = (await res.json()) as { error: string; details: ValidationIssue[] };
+    expect(body.error).toBe('Validation failed');
+    expect(body.details.some((issue) => issue.path === 'range')).toBe(true);
+  });
+
+  it('lets a valid request reach the handler', async () => {
+    const res = await postTeam({ name: 'Engineering' });
+    expect(res.status).toBe(201);
+
+    const body = (await res.json()) as { ok: boolean };
+    expect(body.ok).toBe(true);
+  });
+});

--- a/libs/api/src/http.ts
+++ b/libs/api/src/http.ts
@@ -1,0 +1,104 @@
+import { OpenAPIHono, z, type Hook } from '@hono/zod-openapi';
+import type { Context, Env } from 'hono';
+import type { ErrorResponse } from '@schediochron/core';
+
+/**
+ * HTTP error handling for `@schediochron/api`.
+ *
+ * Everything here produces the single error envelope shipped in the contract
+ * (`ErrorResponse = { error, details? }`, see `openapi.yaml` and
+ * `@schediochron/core`). There is deliberately no second error shape: the typed
+ * helpers below and the request-validation hook all emit this one envelope so
+ * every 4xx answer looks the same to clients.
+ */
+
+/** The 4xx statuses the contract actually uses (see `openapi.yaml`). */
+export type ErrorStatus = 400 | 401 | 403 | 404 | 409;
+
+/**
+ * One field-level validation problem. Intentionally minimal: a dotted path to
+ * the offending field and a human-readable, schema-authored message. Nothing
+ * from the runtime (stack traces, driver errors, SQL) is ever placed here.
+ */
+export interface ValidationIssue {
+  /** Dotted path to the offending field; empty string for the request root. */
+  path: string;
+  /** Human-readable message, authored by the Zod schema. */
+  message: string;
+}
+
+/**
+ * Emit the `ErrorResponse` envelope with the given status. `details` is omitted
+ * entirely when not supplied, matching the contract's optional `details`.
+ */
+export function errorResponse(
+  c: Context,
+  status: ErrorStatus,
+  error: string,
+  details?: unknown,
+) {
+  const body: ErrorResponse =
+    details === undefined ? { error } : { error, details };
+  return c.json(body, status);
+}
+
+/** 400 — malformed or invalid request. */
+export const badRequest = (c: Context, error = 'Bad request', details?: unknown) =>
+  errorResponse(c, 400, error, details);
+
+/** 401 — missing or invalid authentication. */
+export const unauthorized = (
+  c: Context,
+  error = 'Unauthorized',
+  details?: unknown,
+) => errorResponse(c, 401, error, details);
+
+/** 403 — authenticated but not permitted. */
+export const forbidden = (c: Context, error = 'Forbidden', details?: unknown) =>
+  errorResponse(c, 403, error, details);
+
+/** 404 — resource does not exist. */
+export const notFound = (c: Context, error = 'Not found', details?: unknown) =>
+  errorResponse(c, 404, error, details);
+
+/** 409 — request conflicts with current state. */
+export const conflict = (c: Context, error = 'Conflict', details?: unknown) =>
+  errorResponse(c, 409, error, details);
+
+/**
+ * Reduce a `ZodError` to the field-level `details` payload. Only the path and
+ * the schema-authored message survive; the raw error, its `code`s, and any
+ * runtime context are dropped so nothing internal can leak to the client.
+ */
+export function formatZodIssues(error: z.ZodError): ValidationIssue[] {
+  return error.issues.map((issue) => ({
+    path: issue.path.join('.'),
+    message: issue.message,
+  }));
+}
+
+/**
+ * The validation hook shared by every route. `@hono/zod-openapi` runs it after
+ * validating a request against the route's Zod schemas; on failure we answer
+ * 400 in the `ErrorResponse` envelope rather than the library default. On
+ * success we return nothing, letting the handler run.
+ */
+export const validationHook: Hook<unknown, Env, string, Response | undefined> = (
+  result,
+  c,
+) => {
+  if (!result.success) {
+    return badRequest(c, 'Validation failed', formatZodIssues(result.error));
+  }
+  return undefined;
+};
+
+/**
+ * Construct an `OpenAPIHono` router pre-wired with {@link validationHook}. Every
+ * router in the app — the top-level app and each resource group — is built this
+ * way so contract-derived validation and the error envelope apply uniformly as
+ * endpoints (#29–#33) land.
+ */
+export function createRouter(): OpenAPIHono {
+  return new OpenAPIHono({ defaultHook: validationHook });
+}

--- a/libs/api/src/routes/auth.ts
+++ b/libs/api/src/routes/auth.ts
@@ -1,9 +1,9 @@
-import { Hono } from 'hono';
 import type { AuthResponse } from '@schediochron/core';
+import { createRouter } from '../http.js';
 import { stubTokenPair, stubUser } from '../stub-data.js';
 
 /** `/auth` — authentication and token management. Stub responses (#83). */
-export const authRoutes = new Hono();
+export const authRoutes = createRouter();
 
 const authResponse: AuthResponse = { user: stubUser, ...stubTokenPair };
 

--- a/libs/api/src/routes/reports.ts
+++ b/libs/api/src/routes/reports.ts
@@ -1,7 +1,7 @@
-import { Hono } from 'hono';
+import { createRouter } from '../http.js';
 import { stubHoursReportDay } from '../stub-data.js';
 
 /** `/reports` — hours reporting. Stub responses (#83). */
-export const reportRoutes = new Hono();
+export const reportRoutes = createRouter();
 
 reportRoutes.get('/hours', (c) => c.json([stubHoursReportDay], 200));

--- a/libs/api/src/routes/teams.ts
+++ b/libs/api/src/routes/teams.ts
@@ -1,9 +1,9 @@
-import { Hono } from 'hono';
 import type { Team } from '@schediochron/core';
+import { createRouter } from '../http.js';
 import { stubTeam } from '../stub-data.js';
 
 /** `/teams` — team management and membership. Stub responses (#83). */
-export const teamRoutes = new Hono();
+export const teamRoutes = createRouter();
 
 const teamWithId = (id: string): Team => ({ ...stubTeam, id });
 

--- a/libs/api/src/routes/time-entries.ts
+++ b/libs/api/src/routes/time-entries.ts
@@ -1,9 +1,9 @@
-import { Hono } from 'hono';
 import type { TimeEntry } from '@schediochron/core';
+import { createRouter } from '../http.js';
 import { stubCompletedEntry, stubRunningEntry } from '../stub-data.js';
 
 /** `/time-entries` — manual entries and clock-in/clock-out. Stub responses (#83). */
-export const timeEntryRoutes = new Hono();
+export const timeEntryRoutes = createRouter();
 
 const entryWithId = (id: string): TimeEntry => ({ ...stubCompletedEntry, id });
 

--- a/libs/api/src/routes/users.ts
+++ b/libs/api/src/routes/users.ts
@@ -1,9 +1,9 @@
-import { Hono } from 'hono';
 import type { User } from '@schediochron/core';
+import { createRouter } from '../http.js';
 import { stubUser } from '../stub-data.js';
 
 /** `/users` — user management. Stub responses (#83). */
-export const userRoutes = new Hono();
+export const userRoutes = createRouter();
 
 // The requested id is echoed back so the stub reflects the path it was reached
 // through; Phase 2 looks the user up instead.

--- a/libs/api/src/schemas.spec.ts
+++ b/libs/api/src/schemas.spec.ts
@@ -1,0 +1,122 @@
+import { describe, expect, it } from 'bun:test';
+import { OpenAPIHono } from '@hono/zod-openapi';
+import { requestBodySchemas } from './schemas.js';
+
+/**
+ * Contract drift guard.
+ *
+ * Generates OpenAPI schema objects from the request Zod schemas and asserts
+ * they match the request schemas hand-authored in `openapi.yaml`. Both sides
+ * are reduced to a canonical constraint form (type, nullability, format,
+ * lengths, pattern, enum, required, nested properties) so cosmetic differences
+ * — descriptions, key order, the two equivalent ways OpenAPI 3.1 spells a
+ * nullable type — are ignored, while any real constraint drift fails here.
+ */
+
+interface JsonSchema {
+  $ref?: string;
+  type?: string | string[];
+  nullable?: boolean;
+  format?: string;
+  pattern?: string;
+  minLength?: number;
+  maxLength?: number;
+  minimum?: number;
+  minItems?: number;
+  enum?: string[];
+  required?: string[];
+  properties?: Record<string, JsonSchema>;
+  items?: JsonSchema;
+}
+
+interface Normalized {
+  type?: string | string[];
+  nullable?: true;
+  format?: string;
+  pattern?: string;
+  minLength?: number;
+  maxLength?: number;
+  minimum?: number;
+  minItems?: number;
+  enum?: string[];
+  required?: string[];
+  properties?: Record<string, Normalized>;
+  items?: Normalized;
+}
+
+/** `Bun.YAML` is a shipped runtime API not yet in `@types/bun`. */
+const parseYaml = (Bun as unknown as { YAML: { parse(input: string): unknown } })
+  .YAML.parse;
+
+function normalize(
+  schema: JsonSchema,
+  components: Record<string, JsonSchema>,
+): Normalized {
+  if (schema.$ref) {
+    const name = schema.$ref.replace('#/components/schemas/', '');
+    const target = components[name];
+    if (!target) throw new Error(`Unresolved $ref: ${schema.$ref}`);
+    return normalize(target, components);
+  }
+
+  const out: Normalized = {};
+
+  let type = schema.type;
+  let nullable = schema.nullable === true;
+  if (Array.isArray(type)) {
+    nullable = nullable || type.includes('null');
+    const nonNull = type.filter((t) => t !== 'null');
+    type = nonNull.length === 1 ? nonNull[0] : nonNull;
+  }
+  if (type !== undefined) out.type = type;
+  if (nullable) out.nullable = true;
+  if (schema.format !== undefined) out.format = schema.format;
+  if (schema.pattern !== undefined) out.pattern = schema.pattern;
+  if (schema.minLength !== undefined) out.minLength = schema.minLength;
+  if (schema.maxLength !== undefined) out.maxLength = schema.maxLength;
+  if (schema.minimum !== undefined) out.minimum = schema.minimum;
+  if (schema.minItems !== undefined) out.minItems = schema.minItems;
+  if (schema.enum !== undefined) out.enum = [...schema.enum].sort();
+  if (schema.required && schema.required.length > 0) {
+    out.required = [...schema.required].sort();
+  }
+  if (schema.properties !== undefined) {
+    const props: Record<string, Normalized> = {};
+    for (const key of Object.keys(schema.properties).sort()) {
+      props[key] = normalize(schema.properties[key]!, components);
+    }
+    out.properties = props;
+  }
+  if (schema.items !== undefined) {
+    out.items = normalize(schema.items, components);
+  }
+  return out;
+}
+
+const openapiUrl = new URL('../openapi.yaml', import.meta.url);
+const openapiDoc = parseYaml(await Bun.file(openapiUrl).text()) as {
+  components: { schemas: Record<string, JsonSchema> };
+};
+const contractSchemas = openapiDoc.components.schemas;
+
+const registry = new OpenAPIHono();
+for (const [name, schema] of Object.entries(requestBodySchemas)) {
+  registry.openAPIRegistry.register(name, schema);
+}
+const generatedSchemas = registry.getOpenAPIDocument({
+  openapi: '3.1.0',
+  info: { title: 'generated', version: '0' },
+}).components?.schemas as Record<string, JsonSchema>;
+
+describe('request schemas match openapi.yaml', () => {
+  for (const name of Object.keys(requestBodySchemas)) {
+    it(`${name} has no constraint drift`, () => {
+      const contract = contractSchemas[name];
+      expect(contract, `${name} is missing from openapi.yaml`).toBeDefined();
+
+      const fromZod = normalize(generatedSchemas[name]!, generatedSchemas);
+      const fromYaml = normalize(contract!, contractSchemas);
+      expect(fromZod).toEqual(fromYaml);
+    });
+  }
+});

--- a/libs/api/src/schemas.ts
+++ b/libs/api/src/schemas.ts
@@ -1,0 +1,190 @@
+import { z } from '@hono/zod-openapi';
+import type {
+  AddTeamMemberRequest,
+  AdminPasswordResetRequest,
+  CreateTeamRequest,
+  CreateTimeEntryRequest,
+  HoursReportQuery,
+  ListTimeEntriesQuery,
+  LoginRequest,
+  LogoutRequest,
+  RefreshRequest,
+  RegisterRequest,
+  StartTimeEntryRequest,
+  StopTimeEntryRequest,
+  UpdateTeamRequest,
+  UpdateTimeEntryRequest,
+  UpdateUserRequest,
+} from '@schediochron/core';
+
+/**
+ * Zod schemas for every request the contract accepts.
+ *
+ * These are the single source of request validation for `@schediochron/api`.
+ * Two guards keep them from drifting from the contract:
+ *
+ *  - Compile time: the `ContractSchemaAssertions` block below asserts each
+ *    schema's inferred type is identical to the matching request type exported
+ *    by `@schediochron/core` (which itself mirrors `openapi.yaml`). A field
+ *    added, dropped, or retyped on either side fails `tsc`.
+ *  - Test time: `schemas.spec.ts` generates OpenAPI schema objects from the
+ *    `requestBodySchemas` below and asserts they match the request schemas in
+ *    `openapi.yaml`, so constraint drift (lengths, formats, patterns, required
+ *    fields) fails the suite.
+ *
+ * Built with the `z` from `@hono/zod-openapi` so the same schemas can drive both
+ * request validation and OpenAPI generation for the endpoints (#29–#33).
+ */
+
+// --- Auth ---
+
+export const registerRequestSchema = z.object({
+  username: z
+    .string()
+    .min(3)
+    .max(50)
+    .regex(/^[a-zA-Z0-9_-]+$/),
+  password: z.string().min(8),
+  displayName: z.string().min(1).max(100).optional(),
+  email: z.string().email().optional(),
+});
+
+export const loginRequestSchema = z.object({
+  username: z.string(),
+  password: z.string(),
+});
+
+export const refreshRequestSchema = z.object({
+  refreshToken: z.string(),
+});
+
+export const logoutRequestSchema = z.object({
+  refreshToken: z.string(),
+});
+
+// --- Users ---
+
+export const updateUserRequestSchema = z.object({
+  displayName: z.string().max(100).nullable().optional(),
+  email: z.string().email().nullable().optional(),
+  role: z.enum(['admin', 'member']).optional(),
+});
+
+export const adminPasswordResetRequestSchema = z.object({
+  newPassword: z.string().min(8),
+});
+
+// --- Time entries ---
+
+export const createTimeEntryRequestSchema = z.object({
+  startTime: z.string().datetime({ offset: false }),
+  endTime: z.string().datetime({ offset: false }),
+  note: z.string().max(255).optional(),
+});
+
+export const updateTimeEntryRequestSchema = z.object({
+  startTime: z.string().datetime({ offset: false }).optional(),
+  endTime: z.string().datetime({ offset: false }).nullable().optional(),
+  note: z.string().max(255).nullable().optional(),
+});
+
+export const startTimeEntryRequestSchema = z.object({
+  note: z.string().max(255).optional(),
+});
+
+export const stopTimeEntryRequestSchema = z.object({
+  note: z.string().max(255).nullable().optional(),
+});
+
+export const listTimeEntriesQuerySchema = z.object({
+  userId: z.string().uuid().optional(),
+  status: z.enum(['running', 'completed']).optional(),
+});
+
+// --- Teams ---
+
+export const createTeamRequestSchema = z.object({
+  name: z.string().min(1).max(255),
+});
+
+export const updateTeamRequestSchema = z.object({
+  name: z.string().min(1).max(255),
+});
+
+export const addTeamMemberRequestSchema = z.object({
+  userId: z.string().uuid(),
+});
+
+// --- Reports ---
+
+export const hoursReportQuerySchema = z.object({
+  userId: z.string().uuid().optional(),
+  range: z.enum(['day', 'week', 'month']).optional(),
+  from: z.string().date().optional(),
+  to: z.string().date().optional(),
+});
+
+/**
+ * Named request-body schemas, keyed by their `openapi.yaml` component name.
+ * `schemas.spec.ts` iterates this to generate and diff OpenAPI schemas; the
+ * endpoints reference the individual exports above.
+ */
+export const requestBodySchemas = {
+  RegisterRequest: registerRequestSchema,
+  LoginRequest: loginRequestSchema,
+  RefreshRequest: refreshRequestSchema,
+  LogoutRequest: logoutRequestSchema,
+  UpdateUserRequest: updateUserRequestSchema,
+  AdminPasswordResetRequest: adminPasswordResetRequestSchema,
+  CreateTimeEntryRequest: createTimeEntryRequestSchema,
+  UpdateTimeEntryRequest: updateTimeEntryRequestSchema,
+  StartTimeEntryRequest: startTimeEntryRequestSchema,
+  StopTimeEntryRequest: stopTimeEntryRequestSchema,
+  CreateTeamRequest: createTeamRequestSchema,
+  UpdateTeamRequest: updateTeamRequestSchema,
+  AddTeamMemberRequest: addTeamMemberRequestSchema,
+} as const;
+
+// ---------------------------------------------------------------------------
+// Compile-time drift guard: each schema must infer to the matching contract
+// type from `@schediochron/core`. These aliases exist only to be type-checked.
+// ---------------------------------------------------------------------------
+
+type Equal<X, Y> =
+  (<T>() => T extends X ? 1 : 2) extends <T>() => T extends Y ? 1 : 2
+    ? true
+    : false;
+type Expect<T extends true> = T;
+
+export type ContractSchemaAssertions = [
+  Expect<Equal<z.infer<typeof registerRequestSchema>, RegisterRequest>>,
+  Expect<Equal<z.infer<typeof loginRequestSchema>, LoginRequest>>,
+  Expect<Equal<z.infer<typeof refreshRequestSchema>, RefreshRequest>>,
+  Expect<Equal<z.infer<typeof logoutRequestSchema>, LogoutRequest>>,
+  Expect<Equal<z.infer<typeof updateUserRequestSchema>, UpdateUserRequest>>,
+  Expect<
+    Equal<
+      z.infer<typeof adminPasswordResetRequestSchema>,
+      AdminPasswordResetRequest
+    >
+  >,
+  Expect<
+    Equal<z.infer<typeof createTimeEntryRequestSchema>, CreateTimeEntryRequest>
+  >,
+  Expect<
+    Equal<z.infer<typeof updateTimeEntryRequestSchema>, UpdateTimeEntryRequest>
+  >,
+  Expect<
+    Equal<z.infer<typeof startTimeEntryRequestSchema>, StartTimeEntryRequest>
+  >,
+  Expect<
+    Equal<z.infer<typeof stopTimeEntryRequestSchema>, StopTimeEntryRequest>
+  >,
+  Expect<
+    Equal<z.infer<typeof listTimeEntriesQuerySchema>, ListTimeEntriesQuery>
+  >,
+  Expect<Equal<z.infer<typeof createTeamRequestSchema>, CreateTeamRequest>>,
+  Expect<Equal<z.infer<typeof updateTeamRequestSchema>, UpdateTeamRequest>>,
+  Expect<Equal<z.infer<typeof addTeamMemberRequestSchema>, AddTeamMemberRequest>>,
+  Expect<Equal<z.infer<typeof hoursReportQuerySchema>, HoursReportQuery>>,
+];


### PR DESCRIPTION
Closes #71.

Gives `@schediochron/api` a single, contract-driven request-validation and error-handling strategy, wired up before the endpoints (#29–#33) land.

## How validation derives from the contract
- `src/schemas.ts` defines Zod schemas (built with the `z` from `@hono/zod-openapi`) for every request body and query the contract accepts. These are the single source of request validation; endpoints reference them via `createRoute` rather than writing ad-hoc checks.
- Malformed requests are rejected by a **shared validation hook** (`@hono/zod-openapi`'s `defaultHook`, customized in `src/http.ts`) that answers **400** in the existing `ErrorResponse` envelope with a field-level `details` payload. `details` entries carry only `{ path, message }` — the schema-authored message — so no stack trace, driver error, or SQL can leak.
- Every router (the top-level app and each resource group) is now built via `createRouter()`, an `OpenAPIHono` factory pre-wired with that hook, so validation and the envelope apply uniformly as endpoints are added.

## How openapi.yaml and the Zod schemas cannot silently drift
Two independent guards:
1. **Compile time** — `schemas.ts` asserts each schema's inferred type is identical (`Equal<…>`) to the matching request type exported by `@schediochron/core` (which mirrors `openapi.yaml`). A field added, dropped, or retyped on either side fails `tsc`.
2. **Test time** — `schemas.spec.ts` generates OpenAPI schema objects from the Zod schemas and diffs them (normalized: type, nullability, format, lengths, pattern, enum, required, nested properties) against the request schemas in `openapi.yaml`. Any real constraint drift fails the suite. (Verified it catches an injected `min(3)→min(4)` change.)

## Single error envelope preserved
- The one `ErrorResponse = { error, details? }` envelope is unchanged. Typed helpers for the statuses the contract uses — **400, 401, 403, 404, 409** — all emit this shape (`src/http.ts`), as does the validation hook. No second error shape was introduced.
- `app.ts`'s existing `onError`/`notFound` envelope behavior and the `/health` route are preserved; the app is now an `OpenAPIHono` (a `Hono` superset), so all existing tests stay green.

## Verification
- `bun run --filter @schediochron/api build` → pass
- `bun run typecheck` → pass
- `bun run lint` → pass
- `bun run --filter @schediochron/api test` → **100 pass, 0 fail** (was ~71; adds helper-envelope, validation-failure, and drift tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)