### PR TITLE
feature(29) + [api] JWT authentication middleware

### DIFF
--- a/libs/api/src/auth/middleware.spec.ts
+++ b/libs/api/src/auth/middleware.spec.ts
@@ -1,0 +1,144 @@
+import { afterAll, beforeAll, describe, expect, it } from 'bun:test';
+import type { Team } from '@schediochron/core';
+import { createRouter } from '../http.js';
+import {
+  getAuthenticatedUser,
+  isTeamAdmin,
+  requireAuth,
+  requireSystemRole,
+} from './middleware.js';
+import { signAccessToken } from './tokens.js';
+
+const SECRET = 'middleware-test-secret';
+
+// requireAuth verifies with the env secret, so the tokens the tests sign must
+// use the same one. Pin it for this file and restore afterwards.
+let savedSecret: string | undefined;
+beforeAll(() => {
+  savedSecret = process.env.ACCESS_TOKEN_SECRET;
+  process.env.ACCESS_TOKEN_SECRET = SECRET;
+});
+afterAll(() => {
+  if (savedSecret === undefined) delete process.env.ACCESS_TOKEN_SECRET;
+  else process.env.ACCESS_TOKEN_SECRET = savedSecret;
+});
+
+/** A router that echoes the authenticated user from behind requireAuth. */
+function protectedApp() {
+  const app = createRouter();
+  app.use('/me', requireAuth);
+  app.get('/me', (c) => c.json(getAuthenticatedUser(c)));
+  return app;
+}
+
+/** A router requiring a system admin behind requireAuth. */
+function adminApp() {
+  const app = createRouter();
+  app.use('/admin', requireAuth, requireSystemRole('admin'));
+  app.get('/admin', (c) => c.json({ ok: true }));
+  return app;
+}
+
+const bearer = (token: string) => ({ Authorization: `Bearer ${token}` });
+
+describe('requireAuth', () => {
+  const app = protectedApp();
+
+  it('401s with the error envelope when the header is absent', async () => {
+    const res = await app.request('/me');
+    expect(res.status).toBe(401);
+    expect(await res.json()).toEqual({
+      error: 'Missing or malformed Authorization header',
+    });
+  });
+
+  it('401s when the header is not a Bearer token', async () => {
+    const res = await app.request('/me', {
+      headers: { Authorization: 'Token abc' },
+    });
+    expect(res.status).toBe(401);
+  });
+
+  it('401s on a malformed token', async () => {
+    const res = await app.request('/me', { headers: bearer('not.a.jwt') });
+    expect(res.status).toBe(401);
+    expect(await res.json()).toEqual({
+      error: 'Invalid or expired access token',
+    });
+  });
+
+  it('401s on an expired token', async () => {
+    const past = Math.floor(Date.now() / 1000) - 3600;
+    const token = await signAccessToken(
+      { id: 'u1', username: 'ada', role: 'member' },
+      { secret: SECRET, ttlSeconds: 60, now: past },
+    );
+    const res = await app.request('/me', { headers: bearer(token) });
+    expect(res.status).toBe(401);
+  });
+
+  it('attaches the typed identity on a valid token', async () => {
+    const token = await signAccessToken(
+      { id: 'u1', username: 'ada', role: 'member' },
+      { secret: SECRET },
+    );
+    const res = await app.request('/me', { headers: bearer(token) });
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual({
+      id: 'u1',
+      username: 'ada',
+      role: 'member',
+    });
+  });
+});
+
+describe('requireSystemRole', () => {
+  const app = adminApp();
+
+  it('403s a valid token whose role is insufficient', async () => {
+    const token = await signAccessToken(
+      { id: 'u1', username: 'ada', role: 'member' },
+      { secret: SECRET },
+    );
+    const res = await app.request('/admin', { headers: bearer(token) });
+    expect(res.status).toBe(403);
+    expect(await res.json()).toEqual({ error: 'Insufficient role' });
+  });
+
+  it('allows a token with a sufficient role', async () => {
+    const token = await signAccessToken(
+      { id: 'u1', username: 'grace', role: 'admin' },
+      { secret: SECRET },
+    );
+    const res = await app.request('/admin', { headers: bearer(token) });
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual({ ok: true });
+  });
+
+  it('401s before the role check when unauthenticated', async () => {
+    const res = await app.request('/admin');
+    expect(res.status).toBe(401);
+  });
+});
+
+describe('isTeamAdmin', () => {
+  const team: Team = {
+    id: 'team-1',
+    name: 'Engineering',
+    adminIds: ['admin-1'],
+    memberIds: ['admin-1', 'member-1'],
+    createdAt: '2026-01-05T08:00:00Z',
+    updatedAt: '2026-01-05T08:00:00Z',
+  };
+
+  it('is true for a team admin and false for a plain member', () => {
+    expect(isTeamAdmin('admin-1', team)).toBe(true);
+    expect(isTeamAdmin('member-1', team)).toBe(false);
+  });
+
+  it('is independent of the system role — a plain member can be a team admin', () => {
+    // 'member-1' is a system member here yet not a team admin; 'admin-1' need
+    // not be a system admin to administer this team. The axis is membership.
+    expect(isTeamAdmin('someone-else', team)).toBe(false);
+  });
+});

--- a/libs/api/src/auth/middleware.ts
+++ b/libs/api/src/auth/middleware.ts
@@ -1,0 +1,100 @@
+import type { Context, MiddlewareHandler } from 'hono';
+import type { Team, UserRole } from '@schediochron/core';
+import { forbidden, unauthorized } from '../http.js';
+import { verifyAccessToken } from './tokens.js';
+
+/**
+ * JWT authentication and authorisation for `@schediochron/api`.
+ *
+ * Two authorisation axes exist and are deliberately kept separate (ADR-002,
+ * ADR-004):
+ *
+ *   1. the **system role** (`'admin' | 'member'`) carried in the access token —
+ *      an account-level capability, checked with {@link requireSystemRole};
+ *   2. **team-admin** rights over a *specific* team — decided against that
+ *      team's membership, checked with {@link isTeamAdmin}.
+ *
+ * They are not the same check: a system `member` can administer a team, and a
+ * system `admin` need not administer any given team.
+ */
+
+/** The authenticated caller, derived from a verified access token. */
+export interface AuthenticatedUser {
+  id: string;
+  username: string;
+  /** System role (ADR-002). */
+  role: UserRole;
+}
+
+// Type the Hono context variable so `c.get('user')` / `c.set('user', …)` are
+// checked against AuthenticatedUser rather than stashed untyped.
+declare module 'hono' {
+  interface ContextVariableMap {
+    user: AuthenticatedUser;
+  }
+}
+
+const BEARER = /^Bearer (.+)$/;
+
+/**
+ * Requires a valid `Authorization: Bearer <accessToken>`. Missing, malformed,
+ * mis-signed, or expired tokens get 401 in the `ErrorResponse` envelope. On
+ * success the decoded identity is attached to the context as `user`.
+ */
+export const requireAuth: MiddlewareHandler = async (c, next) => {
+  const header = c.req.header('Authorization');
+  const match = header ? BEARER.exec(header) : null;
+  if (!match) {
+    return unauthorized(c, 'Missing or malformed Authorization header');
+  }
+  try {
+    const claims = await verifyAccessToken(match[1]);
+    c.set('user', {
+      id: claims.sub,
+      username: claims.username,
+      role: claims.role,
+    });
+  } catch {
+    return unauthorized(c, 'Invalid or expired access token');
+  }
+  return next();
+};
+
+/**
+ * Reads the authenticated user off the context. Throws if {@link requireAuth}
+ * did not run first — a programming error, not a client error.
+ */
+export function getAuthenticatedUser(c: Context): AuthenticatedUser {
+  const user = c.get('user');
+  if (!user) {
+    throw new Error(
+      'getAuthenticatedUser called on a route that is not behind requireAuth',
+    );
+  }
+  return user;
+}
+
+/**
+ * System-role authorisation (ADR-002): answers 403 unless the caller's account
+ * role is one of `allowed`. Reads the role from the token claim — no database
+ * lookup, no team involved. Must run after {@link requireAuth}.
+ */
+export function requireSystemRole(...allowed: UserRole[]): MiddlewareHandler {
+  return async (c, next) => {
+    const user = getAuthenticatedUser(c);
+    if (!allowed.includes(user.role)) {
+      return forbidden(c, 'Insufficient role');
+    }
+    return next();
+  };
+}
+
+/**
+ * Team-admin authorisation (ADR-004): whether `userId` administers `team`. This
+ * is the second, distinct axis — decided against the team's `adminIds`, not the
+ * token — so it is a predicate the team endpoints (#32) apply with a loaded
+ * `Team`, rather than a token-only middleware.
+ */
+export function isTeamAdmin(userId: string, team: Team): boolean {
+  return team.adminIds.includes(userId);
+}

--- a/libs/api/src/auth/tokens.spec.ts
+++ b/libs/api/src/auth/tokens.spec.ts
@@ -1,0 +1,111 @@
+import { afterEach, beforeEach, describe, expect, it } from 'bun:test';
+import {
+  InvalidAccessTokenError,
+  getAccessTokenSecret,
+  getAccessTokenTtlSeconds,
+  signAccessToken,
+  verifyAccessToken,
+} from './tokens.js';
+
+const SECRET = 'test-signing-secret';
+const subject = { id: 'user-1', username: 'ada', role: 'admin' as const };
+
+let savedSecret: string | undefined;
+let savedTtl: string | undefined;
+
+beforeEach(() => {
+  savedSecret = process.env.ACCESS_TOKEN_SECRET;
+  savedTtl = process.env.ACCESS_TOKEN_TTL_SECONDS;
+});
+
+afterEach(() => {
+  if (savedSecret === undefined) delete process.env.ACCESS_TOKEN_SECRET;
+  else process.env.ACCESS_TOKEN_SECRET = savedSecret;
+  if (savedTtl === undefined) delete process.env.ACCESS_TOKEN_TTL_SECONDS;
+  else process.env.ACCESS_TOKEN_TTL_SECONDS = savedTtl;
+});
+
+describe('signAccessToken / verifyAccessToken', () => {
+  it('round-trips the subject as typed claims', async () => {
+    const token = await signAccessToken(subject, { secret: SECRET });
+    const claims = await verifyAccessToken(token, SECRET);
+    expect(claims.sub).toBe('user-1');
+    expect(claims.username).toBe('ada');
+    expect(claims.role).toBe('admin');
+    expect(claims.exp).toBeGreaterThan(claims.iat);
+  });
+
+  it('rejects a token signed with a different secret', async () => {
+    const token = await signAccessToken(subject, { secret: SECRET });
+    await expect(
+      verifyAccessToken(token, 'other-secret'),
+    ).rejects.toBeInstanceOf(InvalidAccessTokenError);
+  });
+
+  it('rejects a malformed token', async () => {
+    await expect(verifyAccessToken('not.a.jwt', SECRET)).rejects.toBeInstanceOf(
+      InvalidAccessTokenError,
+    );
+  });
+
+  it('rejects an expired token', async () => {
+    const past = Math.floor(Date.now() / 1000) - 3600;
+    const token = await signAccessToken(subject, {
+      secret: SECRET,
+      ttlSeconds: 60,
+      now: past,
+    });
+    await expect(verifyAccessToken(token, SECRET)).rejects.toBeInstanceOf(
+      InvalidAccessTokenError,
+    );
+  });
+
+  it('rejects a well-signed token that lacks the required claims', async () => {
+    // A JWT signed with the right secret but without our claims must still fail.
+    const { sign } = await import('hono/jwt');
+    const token = await sign({ foo: 'bar' }, SECRET);
+    await expect(verifyAccessToken(token, SECRET)).rejects.toBeInstanceOf(
+      InvalidAccessTokenError,
+    );
+  });
+});
+
+describe('getAccessTokenSecret', () => {
+  it('returns the configured secret', () => {
+    process.env.ACCESS_TOKEN_SECRET = SECRET;
+    expect(getAccessTokenSecret()).toBe(SECRET);
+  });
+
+  it('throws when the secret is unset', () => {
+    delete process.env.ACCESS_TOKEN_SECRET;
+    expect(() => getAccessTokenSecret()).toThrow(
+      /ACCESS_TOKEN_SECRET is not set/,
+    );
+  });
+
+  it('throws when the secret is empty', () => {
+    process.env.ACCESS_TOKEN_SECRET = '';
+    expect(() => getAccessTokenSecret()).toThrow(
+      /ACCESS_TOKEN_SECRET is not set/,
+    );
+  });
+});
+
+describe('getAccessTokenTtlSeconds', () => {
+  it('defaults to 15 minutes when unset', () => {
+    delete process.env.ACCESS_TOKEN_TTL_SECONDS;
+    expect(getAccessTokenTtlSeconds()).toBe(900);
+  });
+
+  it('reads a positive integer from the environment', () => {
+    process.env.ACCESS_TOKEN_TTL_SECONDS = '300';
+    expect(getAccessTokenTtlSeconds()).toBe(300);
+  });
+
+  it('rejects a non-positive or non-integer value', () => {
+    process.env.ACCESS_TOKEN_TTL_SECONDS = '0';
+    expect(() => getAccessTokenTtlSeconds()).toThrow(/positive integer/);
+    process.env.ACCESS_TOKEN_TTL_SECONDS = 'abc';
+    expect(() => getAccessTokenTtlSeconds()).toThrow(/positive integer/);
+  });
+});

--- a/libs/api/src/auth/tokens.ts
+++ b/libs/api/src/auth/tokens.ts
@@ -1,0 +1,138 @@
+import { sign, verify } from 'hono/jwt';
+import type { UserRole } from '@schediochron/core';
+
+/**
+ * Access-token issuing and verification (ADR-003).
+ *
+ * Access tokens are stateless signed JWTs: they carry the user's id, username,
+ * and system role as claims, so middleware can authorise without a database
+ * lookup. They are HMAC-signed with a secret that has **no default** — a missing
+ * secret is a configuration error, never something to paper over.
+ */
+
+const SECRET_ENV = 'ACCESS_TOKEN_SECRET';
+const TTL_ENV = 'ACCESS_TOKEN_TTL_SECONDS';
+const DEFAULT_TTL_SECONDS = 15 * 60;
+const ALG = 'HS256';
+
+/** The claims carried by an access token (ADR-003). */
+export interface AccessTokenClaims {
+  /** Subject — the user id (UUID v4). */
+  sub: string;
+  username: string;
+  /** System role (ADR-002) — `'admin' | 'member'`. */
+  role: UserRole;
+  /** Issued-at, seconds since the epoch. */
+  iat: number;
+  /** Expiry, seconds since the epoch. */
+  exp: number;
+}
+
+/** The identity an access token is minted for. */
+export interface AccessTokenSubject {
+  id: string;
+  username: string;
+  role: UserRole;
+}
+
+/** Thrown when a token is absent-of-claims, malformed, mis-signed, or expired. */
+export class InvalidAccessTokenError extends Error {
+  constructor(message = 'Invalid or expired access token') {
+    super(message);
+    this.name = 'InvalidAccessTokenError';
+  }
+}
+
+/**
+ * The HMAC signing secret, from `ACCESS_TOKEN_SECRET`. Throws when unset or
+ * empty — there is deliberately no usable default.
+ */
+export function getAccessTokenSecret(): string {
+  const secret = process.env[SECRET_ENV];
+  if (!secret) {
+    throw new Error(
+      `${SECRET_ENV} is not set — the API cannot sign or verify access tokens without a signing secret.`,
+    );
+  }
+  return secret;
+}
+
+/**
+ * Access-token lifetime in seconds, from `ACCESS_TOKEN_TTL_SECONDS` (a config
+ * concern per ADR-003), defaulting to 15 minutes. A short lifetime is the point
+ * of the dual-token scheme; the refresh token carries the long-lived session.
+ */
+export function getAccessTokenTtlSeconds(): number {
+  const raw = process.env[TTL_ENV];
+  if (raw === undefined) {
+    return DEFAULT_TTL_SECONDS;
+  }
+  const seconds = Number(raw);
+  if (!Number.isInteger(seconds) || seconds <= 0) {
+    throw new Error(
+      `${TTL_ENV} must be a positive integer of seconds, got "${raw}"`,
+    );
+  }
+  return seconds;
+}
+
+/** Mints a signed access token for the subject. */
+export async function signAccessToken(
+  subject: AccessTokenSubject,
+  options: { secret?: string; ttlSeconds?: number; now?: number } = {},
+): Promise<string> {
+  const secret = options.secret ?? getAccessTokenSecret();
+  const ttlSeconds = options.ttlSeconds ?? getAccessTokenTtlSeconds();
+  const iat = options.now ?? Math.floor(Date.now() / 1000);
+  return sign(
+    {
+      sub: subject.id,
+      username: subject.username,
+      role: subject.role,
+      iat,
+      exp: iat + ttlSeconds,
+    },
+    secret,
+    ALG,
+  );
+}
+
+function hasAccessTokenClaims(payload: Record<string, unknown>): boolean {
+  return (
+    typeof payload.sub === 'string' &&
+    typeof payload.username === 'string' &&
+    (payload.role === 'admin' || payload.role === 'member') &&
+    typeof payload.iat === 'number' &&
+    typeof payload.exp === 'number'
+  );
+}
+
+/**
+ * Verifies signature and expiry and returns the typed claims. Every failure —
+ * bad signature, malformed token, expired token, or a token missing the claims
+ * we require — surfaces as {@link InvalidAccessTokenError}, so callers never see
+ * the underlying JWT library errors.
+ */
+export async function verifyAccessToken(
+  token: string,
+  secret: string = getAccessTokenSecret(),
+): Promise<AccessTokenClaims> {
+  let payload: Record<string, unknown>;
+  try {
+    payload = await verify(token, secret, ALG);
+  } catch {
+    throw new InvalidAccessTokenError();
+  }
+  if (!hasAccessTokenClaims(payload)) {
+    throw new InvalidAccessTokenError(
+      'Access token is missing required claims',
+    );
+  }
+  return {
+    sub: payload.sub as string,
+    username: payload.username as string,
+    role: payload.role as UserRole,
+    iat: payload.iat as number,
+    exp: payload.exp as number,
+  };
+}

--- a/libs/api/src/index.ts
+++ b/libs/api/src/index.ts
@@ -1,2 +1,19 @@
 // Public API
 export { app } from './app.js';
+
+export type { AccessTokenClaims, AccessTokenSubject } from './auth/tokens.js';
+export {
+  InvalidAccessTokenError,
+  getAccessTokenSecret,
+  getAccessTokenTtlSeconds,
+  signAccessToken,
+  verifyAccessToken,
+} from './auth/tokens.js';
+
+export type { AuthenticatedUser } from './auth/middleware.js';
+export {
+  getAuthenticatedUser,
+  isTeamAdmin,
+  requireAuth,
+  requireSystemRole,
+} from './auth/middleware.js';


### PR DESCRIPTION
Closes #29. Off a clean `main` (all of wave 1 merged).

Reusable JWT authentication + authorisation for `@schediochron/api`, built on #71's error envelope and helpers. Dependency-free — uses `hono/jwt` (already in the tree).

## `auth/tokens.ts` — stateless access tokens (ADR-003)
- `signAccessToken` / `verifyAccessToken` for HS256 JWTs carrying `sub`, `username`, `role`, `iat`, `exp`.
- Signing secret from **`ACCESS_TOKEN_SECRET` with no usable default** — a missing secret throws. TTL from `ACCESS_TOKEN_TTL_SECONDS` (default 15m; a config concern per ADR-003).
- Every failure — bad signature, malformed, expired, or missing our claims — surfaces as `InvalidAccessTokenError`, so the underlying JWT library errors never reach callers.

## `auth/middleware.ts` — authentication + the two authorisation axes
- `requireAuth`: validates `Authorization: Bearer <token>`, attaches the decoded identity to Hono's context **typed** (via `ContextVariableMap`, read through `getAuthenticatedUser`), and answers **401 in the `ErrorResponse` envelope** for missing / malformed / mis-signed / expired tokens.
- **The two axes are kept deliberately separate** (the issue's key point):
  - `requireSystemRole(...roles)` — account-level role (ADR-002), read from the token claim, **403** on insufficient role;
  - `isTeamAdmin(userId, team)` — per-team rights (ADR-004), decided against the team's `adminIds`, a predicate the team endpoints (#32) apply with a loaded `Team`.
  A system `member` can be a team admin, and a system `admin` need not administer a given team — so they are not the same check.

## Scope
Delivers the reusable middleware and its tests; it is **not** wired onto the stub routes (that would break the stub test suite and duplicates work the endpoints do). Per-route application lands with #30 (logout) and #31–#33, which is why those depend on this.

## Verification
- `bun run --filter @schediochron/api build` / `typecheck` / `lint` ✅ · Prettier-clean
- `bun run --filter @schediochron/api test` → **121 pass, 0 fail** (up from 100): valid/expired/malformed/absent tokens, the 403 role path, secret/TTL config errors, and the team-admin predicate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)