### PR TITLE
feature(32) + [api] implement team management endpoints

### DIFF
--- a/libs/api/src/app.spec.ts
+++ b/libs/api/src/app.spec.ts
@@ -37,23 +37,10 @@ const operations = [
   // return their documented status to this unauthenticated smoke table. Their
   // routing, statuses, and auth are covered end-to-end in time-entries.spec.ts.
 
-  { id: 'listTeams', method: 'GET', path: '/teams', status: 200 },
-  { id: 'createTeam', method: 'POST', path: '/teams', status: 201 },
-  { id: 'getTeam', method: 'GET', path: '/teams/t-1', status: 200 },
-  { id: 'updateTeam', method: 'PATCH', path: '/teams/t-1', status: 200 },
-  { id: 'deleteTeam', method: 'DELETE', path: '/teams/t-1', status: 204 },
-  {
-    id: 'addTeamMember',
-    method: 'POST',
-    path: '/teams/t-1/members',
-    status: 200,
-  },
-  {
-    id: 'removeTeamMember',
-    method: 'DELETE',
-    path: '/teams/t-1/members/u-2',
-    status: 200,
-  },
+  // The /teams operations are omitted here: they are real, auth-protected
+  // endpoints (#32), so a bodyless, tokenless smoke request cannot reach their
+  // documented success status. Their routing, status codes, and authorisation
+  // are covered end-to-end in routes/teams.spec.ts.
 
   { id: 'getHoursReport', method: 'GET', path: '/reports/hours', status: 200 },
 ] as const;
@@ -61,7 +48,7 @@ const operations = [
 describe('openapi.yaml operations', () => {
   it('covers every documented operation', () => {
     // Guards against an endpoint being dropped from the table along with its route.
-    expect(operations).toHaveLength(12);
+    expect(operations).toHaveLength(5);
   });
 
   for (const { id, method, path, status } of operations) {

--- a/libs/api/src/routes/teams.spec.ts
+++ b/libs/api/src/routes/teams.spec.ts
@@ -1,68 +1,394 @@
-import { describe, expect, it } from 'bun:test';
+import { afterEach, beforeEach, describe, expect, it } from 'bun:test';
+import type { Team, TeamRepository } from '@schediochron/core';
 import { validateTeam } from '@schediochron/core';
+import { LastAdminError } from '@schediochron/sql';
 import { app } from '../app.js';
+import { signAccessToken } from '../auth/tokens.js';
+import { setRepositories, type Repositories } from '../repositories.js';
 
-const id = '77777777-7777-4777-8777-777777777777';
+/**
+ * Team-endpoint tests. No PostgreSQL here: an in-memory {@link FakeTeamRepository}
+ * is injected via `setRepositories`, so validation, authentication, the per-team
+ * admin authorisation (403), read scoping, and the repository's `LastAdminError`
+ * → 409 mapping are all exercised against real HTTP requests without a database.
+ */
+
+process.env['ACCESS_TOKEN_SECRET'] = 'test-secret-for-team-endpoints';
+
+const ADMIN_ID = '11111111-1111-4111-8111-111111111111';
+const MEMBER_ID = '22222222-2222-4222-8222-222222222222';
+const OUTSIDER_ID = '33333333-3333-4333-8333-333333333333';
+const NEWCOMER_ID = '44444444-4444-4444-8444-444444444444';
+const TEAM_ID = '55555555-5555-4555-8555-555555555555';
+const SOLO_TEAM_ID = '66666666-6666-4666-8666-666666666666';
+const MISSING_TEAM_ID = '99999999-9999-4999-8999-999999999999';
+
+const clone = (team: Team): Team => ({
+  ...team,
+  adminIds: [...team.adminIds],
+  memberIds: [...team.memberIds],
+});
+
+/** In-memory {@link TeamRepository} mirroring the SQL repo's mutation semantics. */
+class FakeTeamRepository implements TeamRepository {
+  private readonly teams = new Map<string, Team>();
+
+  seed(team: Team): void {
+    this.teams.set(team.id, clone(team));
+  }
+
+  private require(teamId: string): Team {
+    const team = this.teams.get(teamId);
+    if (!team) throw new Error(`Team ${teamId} not found.`);
+    return team;
+  }
+
+  async findById(id: string): Promise<Team | null> {
+    const team = this.teams.get(id);
+    return team ? clone(team) : null;
+  }
+
+  async findAll(): Promise<Team[]> {
+    return [...this.teams.values()].map(clone);
+  }
+
+  async findByUserId(userId: string): Promise<Team[]> {
+    return [...this.teams.values()]
+      .filter((team) => team.memberIds.includes(userId))
+      .map(clone);
+  }
+
+  async create(team: Team): Promise<Team> {
+    this.teams.set(team.id, clone(team));
+    return clone(team);
+  }
+
+  async update(team: Team): Promise<Team> {
+    this.require(team.id);
+    const next = { ...clone(team), updatedAt: new Date().toISOString() };
+    this.teams.set(team.id, next);
+    return clone(next);
+  }
+
+  async delete(id: string): Promise<void> {
+    this.teams.delete(id);
+  }
+
+  async addMember(teamId: string, userId: string): Promise<Team> {
+    const team = this.require(teamId);
+    if (!team.memberIds.includes(userId)) team.memberIds.push(userId);
+    return clone(team);
+  }
+
+  async removeMember(teamId: string, userId: string): Promise<Team> {
+    const team = this.require(teamId);
+    if (team.adminIds.includes(userId) && team.adminIds.length === 1) {
+      throw new LastAdminError(teamId, userId);
+    }
+    team.memberIds = team.memberIds.filter((id) => id !== userId);
+    team.adminIds = team.adminIds.filter((id) => id !== userId);
+    return clone(team);
+  }
+
+  async assignAdmin(teamId: string, userId: string): Promise<Team> {
+    const team = this.require(teamId);
+    if (!team.memberIds.includes(userId)) team.memberIds.push(userId);
+    if (!team.adminIds.includes(userId)) team.adminIds.push(userId);
+    return clone(team);
+  }
+
+  async removeAdmin(teamId: string, userId: string): Promise<Team> {
+    const team = this.require(teamId);
+    if (team.adminIds.includes(userId) && team.adminIds.length === 1) {
+      throw new LastAdminError(teamId, userId);
+    }
+    team.adminIds = team.adminIds.filter((id) => id !== userId);
+    return clone(team);
+  }
+}
+
+const teamFixture = (): Team => ({
+  id: TEAM_ID,
+  name: 'Engineering',
+  adminIds: [ADMIN_ID],
+  memberIds: [ADMIN_ID, MEMBER_ID],
+  createdAt: '2026-01-05T08:00:00Z',
+  updatedAt: '2026-01-05T08:00:00Z',
+});
+
+const soloTeamFixture = (): Team => ({
+  id: SOLO_TEAM_ID,
+  name: 'Solo',
+  adminIds: [ADMIN_ID],
+  memberIds: [ADMIN_ID],
+  createdAt: '2026-01-05T08:00:00Z',
+  updatedAt: '2026-01-05T08:00:00Z',
+});
+
+let repo: FakeTeamRepository;
+
+beforeEach(() => {
+  repo = new FakeTeamRepository();
+  repo.seed(teamFixture());
+  repo.seed(soloTeamFixture());
+  setRepositories({ teams: repo } as unknown as Repositories);
+});
+
+afterEach(() => {
+  setRepositories(undefined);
+});
+
+const tokenFor = (id: string) =>
+  signAccessToken({ id, username: `user-${id.slice(0, 4)}`, role: 'member' });
+
+const authed = (token: string, init: RequestInit = {}): RequestInit => ({
+  ...init,
+  headers: { ...(init.headers ?? {}), Authorization: `Bearer ${token}` },
+});
+
+const jsonBody = (body: unknown): RequestInit => ({
+  method: 'POST',
+  headers: { 'Content-Type': 'application/json' },
+  body: JSON.stringify(body),
+});
 
 describe('GET /teams', () => {
-  it('returns an array of valid teams', async () => {
+  it('401s without a token', async () => {
     const res = await app.request('/teams');
-    const body = (await res.json()) as unknown[];
+    expect(res.status).toBe(401);
+  });
 
-    expect(Array.isArray(body)).toBe(true);
-    expect(body.length).toBeGreaterThan(0);
-    for (const team of body) {
-      expect(validateTeam(team).success).toBe(true);
-    }
+  it('returns only the teams the caller is a member of', async () => {
+    const res = await app.request('/teams', authed(await tokenFor(MEMBER_ID)));
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as Team[];
+    expect(body.map((t) => t.id)).toEqual([TEAM_ID]);
+    expect(body.every((t) => validateTeam(t).success)).toBe(true);
+  });
+
+  it('returns an empty list for a user in no teams', async () => {
+    const res = await app.request(
+      '/teams',
+      authed(await tokenFor(OUTSIDER_ID)),
+    );
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual([]);
   });
 });
 
 describe('POST /teams', () => {
-  it('returns a valid team', async () => {
-    const res = await app.request('/teams', { method: 'POST' });
+  it('401s without a token', async () => {
+    const res = await app.request('/teams', jsonBody({ name: 'New' }));
+    expect(res.status).toBe(401);
+  });
 
-    expect(validateTeam(await res.json()).success).toBe(true);
+  it('400s on an invalid body', async () => {
+    const res = await app.request(
+      '/teams',
+      authed(await tokenFor(OUTSIDER_ID), jsonBody({ name: '' })),
+    );
+    expect(res.status).toBe(400);
+  });
+
+  it('creates a team with the caller as sole admin and member', async () => {
+    const res = await app.request(
+      '/teams',
+      authed(await tokenFor(OUTSIDER_ID), jsonBody({ name: 'Design' })),
+    );
+    expect(res.status).toBe(201);
+    const team = (await res.json()) as Team;
+    expect(validateTeam(team).success).toBe(true);
+    expect(team.name).toBe('Design');
+    expect(team.adminIds).toEqual([OUTSIDER_ID]);
+    expect(team.memberIds).toEqual([OUTSIDER_ID]);
   });
 });
 
 describe('GET /teams/:id', () => {
-  it('returns a valid team carrying the requested id', async () => {
-    const res = await app.request(`/teams/${id}`);
-    const body = (await res.json()) as { id: string };
+  it('returns the team for a member', async () => {
+    const res = await app.request(
+      `/teams/${TEAM_ID}`,
+      authed(await tokenFor(MEMBER_ID)),
+    );
+    expect(res.status).toBe(200);
+    expect(((await res.json()) as Team).id).toBe(TEAM_ID);
+  });
 
-    expect(validateTeam(body).success).toBe(true);
-    expect(body.id).toBe(id);
+  it('404s for a non-member (membership is not probeable)', async () => {
+    const res = await app.request(
+      `/teams/${TEAM_ID}`,
+      authed(await tokenFor(OUTSIDER_ID)),
+    );
+    expect(res.status).toBe(404);
+  });
+
+  it('404s for a missing team', async () => {
+    const res = await app.request(
+      `/teams/${MISSING_TEAM_ID}`,
+      authed(await tokenFor(ADMIN_ID)),
+    );
+    expect(res.status).toBe(404);
   });
 });
 
 describe('PATCH /teams/:id', () => {
-  it('returns a valid team carrying the requested id', async () => {
-    const res = await app.request(`/teams/${id}`, { method: 'PATCH' });
-    const body = (await res.json()) as { id: string };
+  const patch = (body: unknown): RequestInit => ({
+    method: 'PATCH',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(body),
+  });
 
-    expect(validateTeam(body).success).toBe(true);
-    expect(body.id).toBe(id);
+  it('renames the team for an admin', async () => {
+    const res = await app.request(
+      `/teams/${TEAM_ID}`,
+      authed(await tokenFor(ADMIN_ID), patch({ name: 'Platform' })),
+    );
+    expect(res.status).toBe(200);
+    expect(((await res.json()) as Team).name).toBe('Platform');
+  });
+
+  it('403s for a non-admin member', async () => {
+    const res = await app.request(
+      `/teams/${TEAM_ID}`,
+      authed(await tokenFor(MEMBER_ID), patch({ name: 'Platform' })),
+    );
+    expect(res.status).toBe(403);
+  });
+
+  it('400s on an invalid body for an admin', async () => {
+    const res = await app.request(
+      `/teams/${TEAM_ID}`,
+      authed(await tokenFor(ADMIN_ID), patch({ name: '' })),
+    );
+    expect(res.status).toBe(400);
+  });
+
+  it('404s for a missing team', async () => {
+    const res = await app.request(
+      `/teams/${MISSING_TEAM_ID}`,
+      authed(await tokenFor(ADMIN_ID), patch({ name: 'Platform' })),
+    );
+    expect(res.status).toBe(404);
+  });
+});
+
+describe('DELETE /teams/:id', () => {
+  const del = (token: string): RequestInit =>
+    authed(token, { method: 'DELETE' });
+
+  it('deletes a team the admin is the only member of', async () => {
+    const res = await app.request(
+      `/teams/${SOLO_TEAM_ID}`,
+      del(await tokenFor(ADMIN_ID)),
+    );
+    expect(res.status).toBe(204);
+  });
+
+  it('409s when the team still has other members', async () => {
+    const res = await app.request(
+      `/teams/${TEAM_ID}`,
+      del(await tokenFor(ADMIN_ID)),
+    );
+    expect(res.status).toBe(409);
+  });
+
+  it('403s for a non-admin member', async () => {
+    const res = await app.request(
+      `/teams/${SOLO_TEAM_ID}`,
+      del(await tokenFor(MEMBER_ID)),
+    );
+    expect(res.status).toBe(403);
+  });
+
+  it('404s for a missing team', async () => {
+    const res = await app.request(
+      `/teams/${MISSING_TEAM_ID}`,
+      del(await tokenFor(ADMIN_ID)),
+    );
+    expect(res.status).toBe(404);
   });
 });
 
 describe('POST /teams/:id/members', () => {
-  it('returns the updated team', async () => {
-    const res = await app.request(`/teams/${id}/members`, { method: 'POST' });
-    const body = (await res.json()) as { id: string };
+  it('adds a member for an admin and returns the updated team', async () => {
+    const res = await app.request(
+      `/teams/${TEAM_ID}/members`,
+      authed(await tokenFor(ADMIN_ID), jsonBody({ userId: NEWCOMER_ID })),
+    );
+    expect(res.status).toBe(200);
+    const team = (await res.json()) as Team;
+    expect(validateTeam(team).success).toBe(true);
+    expect(team.memberIds).toContain(NEWCOMER_ID);
+  });
 
-    expect(validateTeam(body).success).toBe(true);
-    expect(body.id).toBe(id);
+  it('403s for a non-admin member', async () => {
+    const res = await app.request(
+      `/teams/${TEAM_ID}/members`,
+      authed(await tokenFor(MEMBER_ID), jsonBody({ userId: NEWCOMER_ID })),
+    );
+    expect(res.status).toBe(403);
+  });
+
+  it('409s when the user is already a member', async () => {
+    const res = await app.request(
+      `/teams/${TEAM_ID}/members`,
+      authed(await tokenFor(ADMIN_ID), jsonBody({ userId: MEMBER_ID })),
+    );
+    expect(res.status).toBe(409);
+  });
+
+  it('400s on an invalid body', async () => {
+    const res = await app.request(
+      `/teams/${TEAM_ID}/members`,
+      authed(await tokenFor(ADMIN_ID), jsonBody({ userId: 'not-a-uuid' })),
+    );
+    expect(res.status).toBe(400);
+  });
+
+  it('404s for a missing team', async () => {
+    const res = await app.request(
+      `/teams/${MISSING_TEAM_ID}/members`,
+      authed(await tokenFor(ADMIN_ID), jsonBody({ userId: NEWCOMER_ID })),
+    );
+    expect(res.status).toBe(404);
   });
 });
 
 describe('DELETE /teams/:id/members/:userId', () => {
-  it('returns the updated team', async () => {
-    const res = await app.request(`/teams/${id}/members/u-2`, {
-      method: 'DELETE',
-    });
-    const body = (await res.json()) as { id: string };
+  const del = (token: string): RequestInit =>
+    authed(token, { method: 'DELETE' });
 
-    expect(validateTeam(body).success).toBe(true);
-    expect(body.id).toBe(id);
+  it('removes a member for an admin and returns the updated team', async () => {
+    const res = await app.request(
+      `/teams/${TEAM_ID}/members/${MEMBER_ID}`,
+      del(await tokenFor(ADMIN_ID)),
+    );
+    expect(res.status).toBe(200);
+    const team = (await res.json()) as Team;
+    expect(team.memberIds).not.toContain(MEMBER_ID);
+  });
+
+  it('409s when removing the last admin (LastAdminError)', async () => {
+    const res = await app.request(
+      `/teams/${TEAM_ID}/members/${ADMIN_ID}`,
+      del(await tokenFor(ADMIN_ID)),
+    );
+    expect(res.status).toBe(409);
+  });
+
+  it('403s for a non-admin member', async () => {
+    const res = await app.request(
+      `/teams/${TEAM_ID}/members/${MEMBER_ID}`,
+      del(await tokenFor(MEMBER_ID)),
+    );
+    expect(res.status).toBe(403);
+  });
+
+  it('404s for a missing team', async () => {
+    const res = await app.request(
+      `/teams/${MISSING_TEAM_ID}/members/${MEMBER_ID}`,
+      del(await tokenFor(ADMIN_ID)),
+    );
+    expect(res.status).toBe(404);
   });
 });

--- a/libs/api/src/routes/teams.ts
+++ b/libs/api/src/routes/teams.ts
@@ -1,26 +1,187 @@
+import type { Context } from 'hono';
 import type { Team } from '@schediochron/core';
-import { createRouter } from '../http.js';
-import { stubTeam } from '../stub-data.js';
+import { LastAdminError } from '@schediochron/sql';
+import {
+  getAuthenticatedUser,
+  isTeamAdmin,
+  requireAuth,
+} from '../auth/middleware.js';
+import {
+  badRequest,
+  conflict,
+  createRouter,
+  forbidden,
+  formatZodIssues,
+  notFound,
+} from '../http.js';
+import { provideRepositories } from '../repositories.js';
+import {
+  addTeamMemberRequestSchema,
+  createTeamRequestSchema,
+  updateTeamRequestSchema,
+} from '../schemas.js';
 
-/** `/teams` — team management and membership. Stub responses (#83). */
+/**
+ * `/teams` — team management and membership (ADR-004).
+ *
+ * Two authorisation axes apply. Reads are scoped to teams the caller belongs to
+ * (`findByUserId`); a team you are not in is indistinguishable from one that does
+ * not exist (404). Mutations require **team-admin** rights over the *loaded* team
+ * — `isTeamAdmin(user.id, team)`, a per-team decision distinct from the system
+ * role — and answer 403 otherwise.
+ *
+ * The membership invariants (`adminIds ⊆ memberIds`, at least one admin) are
+ * enforced by the repository's dedicated `addMember`/`removeMember` mutations,
+ * not by a read-modify-write here; `LastAdminError` from that layer maps to 409.
+ */
 export const teamRoutes = createRouter();
 
-const teamWithId = (id: string): Team => ({ ...stubTeam, id });
+teamRoutes.use('*', provideRepositories, requireAuth);
 
-teamRoutes.get('/', (c) => c.json([stubTeam], 200));
+/** Reads the request body as JSON, or `undefined` when absent/malformed. */
+async function readJsonBody(c: Context): Promise<unknown> {
+  try {
+    return await c.req.json();
+  } catch {
+    return undefined;
+  }
+}
 
-teamRoutes.post('/', (c) => c.json(stubTeam, 201));
+// GET /teams — teams the authenticated user belongs to.
+teamRoutes.get('/', async (c) => {
+  const { teams } = c.get('repositories');
+  const user = getAuthenticatedUser(c);
+  return c.json(await teams.findByUserId(user.id), 200);
+});
 
-teamRoutes.get('/:id', (c) => c.json(teamWithId(c.req.param('id')), 200));
+// POST /teams — create a team; the creator becomes its first admin and member.
+teamRoutes.post('/', async (c) => {
+  const { teams } = c.get('repositories');
+  const user = getAuthenticatedUser(c);
 
-teamRoutes.patch('/:id', (c) => c.json(teamWithId(c.req.param('id')), 200));
+  const parsed = createTeamRequestSchema.safeParse(await readJsonBody(c));
+  if (!parsed.success) {
+    return badRequest(c, 'Validation failed', formatZodIssues(parsed.error));
+  }
 
-teamRoutes.delete('/:id', (c) => c.body(null, 204));
+  const now = new Date().toISOString();
+  const team: Team = {
+    id: crypto.randomUUID(),
+    name: parsed.data.name,
+    adminIds: [user.id],
+    memberIds: [user.id],
+    createdAt: now,
+    updatedAt: now,
+  };
+  return c.json(await teams.create(team), 201);
+});
 
-teamRoutes.post('/:id/members', (c) =>
-  c.json(teamWithId(c.req.param('id')), 200),
-);
+// GET /teams/:id — fetch a team; visible only to its members.
+teamRoutes.get('/:id', async (c) => {
+  const { teams } = c.get('repositories');
+  const user = getAuthenticatedUser(c);
 
-teamRoutes.delete('/:id/members/:userId', (c) =>
-  c.json(teamWithId(c.req.param('id')), 200),
-);
+  const team = await teams.findById(c.req.param('id'));
+  // A team the caller is not a member of is not distinguishable from a missing
+  // one — both answer 404 so membership is not probeable.
+  if (!team || !team.memberIds.includes(user.id)) {
+    return notFound(c, 'Team not found');
+  }
+  return c.json(team, 200);
+});
+
+// PATCH /teams/:id — rename a team; team admin only.
+teamRoutes.patch('/:id', async (c) => {
+  const { teams } = c.get('repositories');
+  const user = getAuthenticatedUser(c);
+
+  const team = await teams.findById(c.req.param('id'));
+  if (!team) {
+    return notFound(c, 'Team not found');
+  }
+  if (!isTeamAdmin(user.id, team)) {
+    return forbidden(c, 'Only a team admin may update this team');
+  }
+
+  const parsed = updateTeamRequestSchema.safeParse(await readJsonBody(c));
+  if (!parsed.success) {
+    return badRequest(c, 'Validation failed', formatZodIssues(parsed.error));
+  }
+
+  const updated = await teams.update({ ...team, name: parsed.data.name });
+  return c.json(updated, 200);
+});
+
+// DELETE /teams/:id — delete a team; team admin only, and only when empty of
+// other members.
+teamRoutes.delete('/:id', async (c) => {
+  const { teams } = c.get('repositories');
+  const user = getAuthenticatedUser(c);
+
+  const team = await teams.findById(c.req.param('id'));
+  if (!team) {
+    return notFound(c, 'Team not found');
+  }
+  if (!isTeamAdmin(user.id, team)) {
+    return forbidden(c, 'Only a team admin may delete this team');
+  }
+  if (team.memberIds.some((memberId) => memberId !== user.id)) {
+    return conflict(
+      c,
+      'Team still has other members — remove them before deleting the team',
+    );
+  }
+
+  await teams.delete(team.id);
+  return c.body(null, 204);
+});
+
+// POST /teams/:id/members — add a member; team admin only.
+teamRoutes.post('/:id/members', async (c) => {
+  const { teams } = c.get('repositories');
+  const user = getAuthenticatedUser(c);
+
+  const team = await teams.findById(c.req.param('id'));
+  if (!team) {
+    return notFound(c, 'Team not found');
+  }
+  if (!isTeamAdmin(user.id, team)) {
+    return forbidden(c, 'Only a team admin may add members to this team');
+  }
+
+  const parsed = addTeamMemberRequestSchema.safeParse(await readJsonBody(c));
+  if (!parsed.success) {
+    return badRequest(c, 'Validation failed', formatZodIssues(parsed.error));
+  }
+  if (team.memberIds.includes(parsed.data.userId)) {
+    return conflict(c, 'User is already a member of this team');
+  }
+
+  const updated = await teams.addMember(team.id, parsed.data.userId);
+  return c.json(updated, 200);
+});
+
+// DELETE /teams/:id/members/:userId — remove a member; team admin only. Removing
+// the last admin is rejected by the repository (409).
+teamRoutes.delete('/:id/members/:userId', async (c) => {
+  const { teams } = c.get('repositories');
+  const user = getAuthenticatedUser(c);
+
+  const team = await teams.findById(c.req.param('id'));
+  if (!team) {
+    return notFound(c, 'Team not found');
+  }
+  if (!isTeamAdmin(user.id, team)) {
+    return forbidden(c, 'Only a team admin may remove members from this team');
+  }
+
+  try {
+    const updated = await teams.removeMember(team.id, c.req.param('userId'));
+    return c.json(updated, 200);
+  } catch (err) {
+    if (err instanceof LastAdminError) {
+      return conflict(c, 'Cannot remove the last admin from the team');
+    }
+    throw err;
+  }
+});


### PR DESCRIPTION
Closes #32.

Replaces the `/teams` stub handlers in `@schediochron/api` with real,
repository-backed team management. Stacked on the repository-injection seam
(PR #137 / `chore/api-repository-injection`) — merge that first.

## What changed
All seven `/teams` operations from `openapi.yaml` are implemented, request/response
shapes and status codes matched exactly:

- `GET /teams` — teams the caller belongs to (`findByUserId`)
- `POST /teams` — create (201); creator becomes first admin + member (ADR-004)
- `GET /teams/{id}` — visible to members only
- `PATCH /teams/{id}` — rename (team admin only)
- `DELETE /teams/{id}` — delete (204, team admin only)
- `POST /teams/{id}/members` — add member, returns updated team (200)
- `DELETE /teams/{id}/members/{userId}` — remove member, returns updated team (200)

Wired per the shared pattern: `teamRoutes.use('*', provideRepositories, requireAuth)`.

## Authorization (the two axes, ADR-004)
Reads are **scoped to membership**: `listTeams` returns only the caller's teams,
and `getTeam` of a team you are not in answers 404 (membership is not probeable).

Mutations are gated on **team-admin** rights over the *loaded* team via
`isTeamAdmin(user.id, team)` — a per-team decision distinct from the system role —
answering 403 otherwise.

The ADR-004 409 invariants are enforced: non-empty delete, duplicate member add,
and removing the last admin (`LastAdminError` from `@schediochron/sql` mapped to
409). Membership changes go through the repo's `addMember`/`removeMember`
mutations, never a read-modify-write of the whole team.

## Tests
No live PostgreSQL in this environment, so the handlers are exercised end-to-end
against the real `app` with an injected **in-memory fake `TeamRepository`**
(`setRepositories`), covering validation (400), auth (401), team-admin (403),
read scoping, status codes, and every 409 path — including `LastAdminError` → 409.

`app.spec.ts`'s stub-era smoke table dropped its `/teams` rows: those endpoints
are now real and auth-protected, so a bodyless/tokenless smoke request cannot
reach their documented success status; they are fully covered by
`routes/teams.spec.ts`.

## Verification
- `bun run --filter @schediochron/api build` — PASS
- `bun run typecheck` — PASS
- `bun run lint` — PASS
- `bun run --filter @schediochron/api test` — 130 pass / 0 fail

🤖 Generated with [Claude Code](https://claude.com/claude-code)