### PR TITLE
feature(33) + [api] implement hours reporting endpoint

### DIFF
--- a/libs/api/src/app.spec.ts
+++ b/libs/api/src/app.spec.ts
@@ -42,13 +42,16 @@ const operations = [
   // documented success status. Their routing, status codes, and authorisation
   // are covered end-to-end in routes/teams.spec.ts.
 
-  { id: 'getHoursReport', method: 'GET', path: '/reports/hours', status: 200 },
+  // getHoursReport is omitted here: it is a real, auth-protected endpoint (#33),
+  // so a tokenless smoke request cannot reach its documented success status. Its
+  // routing, status codes, aggregation, and authorisation are covered end-to-end
+  // in routes/reports.spec.ts.
 ] as const;
 
 describe('openapi.yaml operations', () => {
   it('covers every documented operation', () => {
     // Guards against an endpoint being dropped from the table along with its route.
-    expect(operations).toHaveLength(5);
+    expect(operations).toHaveLength(4);
   });
 
   for (const { id, method, path, status } of operations) {

--- a/libs/api/src/routes/reports.spec.ts
+++ b/libs/api/src/routes/reports.spec.ts
@@ -1,48 +1,192 @@
-import { describe, expect, it } from 'bun:test';
-import { computeDuration, validateTimeEntry } from '@schediochron/core';
-import type { TimeEntry } from '@schediochron/core';
+import { afterAll, afterEach, beforeAll, describe, expect, it } from 'bun:test';
+import type { TimeEntry, TimeEntryStatus } from '@schediochron/core';
+import { validateTimeEntry } from '@schediochron/core';
 import { app } from '../app.js';
+import { setRepositories, type Repositories } from '../repositories.js';
+import { signAccessToken } from '../auth/tokens.js';
+
+const SECRET = 'reports-test-secret';
+const USER_ID = '11111111-1111-4111-8111-111111111111';
+const OTHER_USER_ID = '22222222-2222-4222-8222-222222222222';
+
+// requireAuth verifies with the env secret, so tokens the tests sign must use
+// the same one. Pin it for this file and restore afterwards.
+let savedSecret: string | undefined;
+beforeAll(() => {
+  savedSecret = process.env.ACCESS_TOKEN_SECRET;
+  process.env.ACCESS_TOKEN_SECRET = SECRET;
+});
+afterAll(() => {
+  if (savedSecret === undefined) delete process.env.ACCESS_TOKEN_SECRET;
+  else process.env.ACCESS_TOKEN_SECRET = savedSecret;
+});
+
+afterEach(() => {
+  // Never leave an override in place for other suites.
+  setRepositories(undefined);
+});
+
+const bearer = (token: string) => ({ Authorization: `Bearer ${token}` });
+
+/** A completed entry with valid, contract-shaped fields. */
+function completed(id: string, startTime: string, endTime: string): TimeEntry {
+  return {
+    id,
+    userId: USER_ID,
+    startTime,
+    endTime,
+    status: 'completed',
+    note: null,
+    createdAt: startTime,
+    updatedAt: endTime,
+  };
+}
+
+// Two entries on 2026-03-10 (150 + 60 = 210 min) and one on 2026-03-11 (45 min).
+const ENTRIES: TimeEntry[] = [
+  completed(
+    '33333333-3333-4333-8333-333333333331',
+    '2026-03-10T09:00:00Z',
+    '2026-03-10T11:30:00Z',
+  ),
+  completed(
+    '33333333-3333-4333-8333-333333333332',
+    '2026-03-10T13:00:00Z',
+    '2026-03-10T14:00:00Z',
+  ),
+  completed(
+    '33333333-3333-4333-8333-333333333333',
+    '2026-03-11T08:00:00Z',
+    '2026-03-11T08:45:00Z',
+  ),
+];
+
+interface FindFilter {
+  userId?: string;
+  status?: TimeEntryStatus;
+  from?: string;
+  to?: string;
+}
+
+/**
+ * Installs an in-memory `timeEntries` repository that returns `entries` for any
+ * `find`, recording the filter it was called with. The other repositories and
+ * CRUD methods are absent — the reporting handler only reaches for
+ * `timeEntries.find`.
+ */
+function installRepositories(entries: TimeEntry[]): {
+  lastFilter?: FindFilter;
+} {
+  const calls: { lastFilter?: FindFilter } = {};
+  const timeEntries = {
+    find(filter: FindFilter): Promise<TimeEntry[]> {
+      calls.lastFilter = filter;
+      return Promise.resolve(entries);
+    },
+  };
+  setRepositories({ timeEntries } as unknown as Repositories);
+  return calls;
+}
+
+async function tokenFor(id: string, role: 'admin' | 'member'): Promise<string> {
+  return signAccessToken({ id, username: 'ada', role }, { secret: SECRET });
+}
 
 describe('GET /reports/hours', () => {
-  it('returns an array of daily summaries', async () => {
+  it('401s without an access token', async () => {
+    installRepositories(ENTRIES);
     const res = await app.request('/reports/hours');
-    const body = (await res.json()) as unknown[];
-
-    expect(Array.isArray(body)).toBe(true);
-    expect(body.length).toBeGreaterThan(0);
+    expect(res.status).toBe(401);
   });
 
-  it('shapes each day as date, totalMinutes and valid entries', async () => {
-    const res = await app.request('/reports/hours');
+  it('400s on an invalid query parameter, in the error envelope', async () => {
+    installRepositories(ENTRIES);
+    const token = await tokenFor(USER_ID, 'member');
+    const res = await app.request('/reports/hours?from=not-a-date', {
+      headers: bearer(token),
+    });
+    expect(res.status).toBe(400);
+    const body = (await res.json()) as { error: string; details?: unknown };
+    expect(body.error).toBe('Validation failed');
+    expect(Array.isArray(body.details)).toBe(true);
+  });
+
+  it('buckets completed entries by day and sums each day, ascending', async () => {
+    installRepositories(ENTRIES);
+    const token = await tokenFor(USER_ID, 'member');
+    const res = await app.request('/reports/hours', { headers: bearer(token) });
+    expect(res.status).toBe(200);
+
     const body = (await res.json()) as {
       date: string;
       totalMinutes: number;
-      entries: unknown[];
+      entries: TimeEntry[];
     }[];
 
+    expect(body.map((d) => d.date)).toEqual(['2026-03-10', '2026-03-11']);
+
+    const [day1, day2] = body;
+    // 09:00→11:30 (150) + 13:00→14:00 (60) = 210
+    expect(day1.totalMinutes).toBe(210);
+    expect(day1.entries).toHaveLength(2);
+    // 08:00→08:45 = 45
+    expect(day2.totalMinutes).toBe(45);
+    expect(day2.entries).toHaveLength(1);
+
     for (const day of body) {
-      expect(day.date).toMatch(/^\d{4}-\d{2}-\d{2}$/);
-      expect(Number.isInteger(day.totalMinutes)).toBe(true);
-      expect(day.totalMinutes).toBeGreaterThanOrEqual(0);
       for (const entry of day.entries) {
         expect(validateTimeEntry(entry).success).toBe(true);
       }
     }
   });
 
-  it('reports totalMinutes consistent with the entries it lists', async () => {
-    const res = await app.request('/reports/hours');
-    const body = (await res.json()) as {
-      totalMinutes: number;
-      entries: TimeEntry[];
-    }[];
+  it('requests only completed entries for the authenticated user', async () => {
+    const calls = installRepositories(ENTRIES);
+    const token = await tokenFor(USER_ID, 'member');
+    await app.request('/reports/hours', { headers: bearer(token) });
 
-    for (const day of body) {
-      const summed = day.entries.reduce(
-        (total, entry) => total + (computeDuration(entry) ?? 0) / 60_000,
-        0,
-      );
-      expect(summed).toBe(day.totalMinutes);
-    }
+    expect(calls.lastFilter?.userId).toBe(USER_ID);
+    expect(calls.lastFilter?.status).toBe('completed');
+  });
+
+  it('passes an explicit from/to window through to the repository', async () => {
+    const calls = installRepositories(ENTRIES);
+    const token = await tokenFor(USER_ID, 'member');
+    await app.request('/reports/hours?from=2026-03-01&to=2026-03-31', {
+      headers: bearer(token),
+    });
+
+    expect(calls.lastFilter?.from).toBe('2026-03-01');
+    expect(calls.lastFilter?.to).toBe('2026-03-31');
+  });
+
+  it('resolves the range shorthand to a window ending today', async () => {
+    const calls = installRepositories(ENTRIES);
+    const token = await tokenFor(USER_ID, 'member');
+    await app.request('/reports/hours?range=day', { headers: bearer(token) });
+
+    const today = new Date().toISOString().slice(0, 10);
+    // range=day is a single-day window: from and to are both today.
+    expect(calls.lastFilter?.from).toBe(today);
+    expect(calls.lastFilter?.to).toBe(today);
+  });
+
+  it('403s a member reporting on another user', async () => {
+    installRepositories(ENTRIES);
+    const token = await tokenFor(USER_ID, 'member');
+    const res = await app.request(`/reports/hours?userId=${OTHER_USER_ID}`, {
+      headers: bearer(token),
+    });
+    expect(res.status).toBe(403);
+  });
+
+  it('lets an admin report on another user', async () => {
+    const calls = installRepositories(ENTRIES);
+    const token = await tokenFor(USER_ID, 'admin');
+    const res = await app.request(`/reports/hours?userId=${OTHER_USER_ID}`, {
+      headers: bearer(token),
+    });
+    expect(res.status).toBe(200);
+    expect(calls.lastFilter?.userId).toBe(OTHER_USER_ID);
   });
 });

--- a/libs/api/src/routes/reports.ts
+++ b/libs/api/src/routes/reports.ts
@@ -1,7 +1,120 @@
-import { createRouter } from '../http.js';
-import { stubHoursReportDay } from '../stub-data.js';
+import type {
+  HoursReportDay,
+  HoursReportQuery,
+  TimeEntry,
+} from '@schediochron/core';
+import { computeDuration } from '@schediochron/core';
+import { getAuthenticatedUser, requireAuth } from '../auth/middleware.js';
+import {
+  badRequest,
+  createRouter,
+  forbidden,
+  formatZodIssues,
+} from '../http.js';
+import { provideRepositories } from '../repositories.js';
+import { hoursReportQuerySchema } from '../schemas.js';
 
-/** `/reports` — hours reporting. Stub responses (#83). */
+/**
+ * `/reports` — hours reporting (#33).
+ *
+ * `GET /reports/hours` returns a daily breakdown of completed hours for a user
+ * over a date window. Only completed entries contribute: running entries have no
+ * `endTime` and therefore no duration (ADR-001). Duration is derived per entry
+ * via {@link computeDuration} and never stored, so the report re-derives every
+ * `totalMinutes` from the entries it lists.
+ */
 export const reportRoutes = createRouter();
 
-reportRoutes.get('/hours', (c) => c.json([stubHoursReportDay], 200));
+reportRoutes.use('*', provideRepositories, requireAuth);
+
+reportRoutes.get('/hours', async (c) => {
+  const parsed = hoursReportQuerySchema.safeParse(c.req.query());
+  if (!parsed.success) {
+    return badRequest(c, 'Validation failed', formatZodIssues(parsed.error));
+  }
+  const query = parsed.data;
+  const user = getAuthenticatedUser(c);
+
+  // Default to the caller's own data; only admins may report on another user.
+  const targetUserId = query.userId ?? user.id;
+  if (targetUserId !== user.id && user.role !== 'admin') {
+    return forbidden(c, 'Cannot report on another user');
+  }
+
+  const { from, to } = resolveWindow(query);
+
+  const { timeEntries } = c.get('repositories');
+  const entries = await timeEntries.find({
+    userId: targetUserId,
+    from,
+    to,
+    status: 'completed',
+  });
+
+  return c.json(aggregateByDay(entries), 200);
+});
+
+/**
+ * The reporting window as inclusive ISO 8601 dates. An explicit `from`/`to`
+ * overrides the `range` shorthand; otherwise `range` (defaulting to `week`) is
+ * resolved to a span of days ending today.
+ */
+function resolveWindow(query: HoursReportQuery): {
+  from?: string;
+  to?: string;
+} {
+  if (query.from !== undefined || query.to !== undefined) {
+    return { from: query.from, to: query.to };
+  }
+  const spanDays = rangeSpanDays(query.range ?? 'week');
+  const today = new Date();
+  const start = new Date(today);
+  start.setUTCDate(start.getUTCDate() - (spanDays - 1));
+  return { from: isoDate(start), to: isoDate(today) };
+}
+
+/** Days covered by a `range` shorthand, inclusive of today. */
+function rangeSpanDays(range: NonNullable<HoursReportQuery['range']>): number {
+  switch (range) {
+    case 'day':
+      return 1;
+    case 'week':
+      return 7;
+    case 'month':
+      return 30;
+  }
+}
+
+/** The UTC calendar date (`YYYY-MM-DD`) of a timestamp. */
+function isoDate(date: Date): string {
+  return date.toISOString().slice(0, 10);
+}
+
+/**
+ * Buckets completed entries by the UTC date of their `startTime`, summing each
+ * day's durations into `totalMinutes`. Days are returned in ascending date order
+ * so the breakdown is deterministic.
+ */
+function aggregateByDay(entries: TimeEntry[]): HoursReportDay[] {
+  const byDay = new Map<string, TimeEntry[]>();
+  for (const entry of entries) {
+    const date = entry.startTime.slice(0, 10);
+    const bucket = byDay.get(date);
+    if (bucket) {
+      bucket.push(entry);
+    } else {
+      byDay.set(date, [entry]);
+    }
+  }
+
+  return [...byDay.entries()]
+    .sort(([a], [b]) => a.localeCompare(b))
+    .map(([date, dayEntries]) => ({
+      date,
+      totalMinutes: dayEntries.reduce(
+        (total, entry) => total + (computeDuration(entry) ?? 0) / 60_000,
+        0,
+      ),
+      entries: dayEntries,
+    }));
+}


### PR DESCRIPTION
Closes #33.

Stacked on the repository-injection seam (PR #137) — base this against
`chore/api-repository-injection`, not `main`.

## What this does
Replaces the `/reports/hours` stub with a real handler that returns a daily
breakdown of completed hours for a user over a date window.

- Validates the query with `hoursReportQuerySchema` (`safeParse` of
  `c.req.query()`); invalid parameters answer `400` in the `ErrorResponse`
  envelope via `formatZodIssues`.
- Wired behind `provideRepositories` + `requireAuth`, matching the sibling
  endpoint PRs. Defaults the report to the authenticated user; only admins may
  report on another `userId`, else `403`.
- Loads `status: 'completed'` entries through the injected `timeEntries` repo
  and aggregates them into ascending per-day buckets keyed by the UTC date of
  `startTime`. Each day's `totalMinutes` is re-derived from its entries with
  `computeDuration` — duration is never stored (ADR-001).
- Resolves the `range` shorthand (`day`/`week`/`month`) into a `from`/`to`
  window ending today; an explicit `from`/`to` overrides it.

## Tests
Handler tests inject an in-memory fake `TimeEntryRepository` via
`setRepositories`, mint tokens with `signAccessToken` under a pinned
`ACCESS_TOKEN_SECRET`, and reset with `setRepositories(undefined)` in teardown —
no PostgreSQL required. They assert day-bucketing and exact totals (09:00→11:30
= 150 min; a second same-day entry sums to 210; a next-day entry = 45), the
`completed`-only + correct-user filter passed to the repo, the `range`/`from`/`to`
window resolution, query-validation `400`, unauthenticated `401`, and the
admin-vs-member `403` split.

`getHoursReport` is dropped from the `app.spec` conformance table now that it is
auth-protected (a tokenless smoke request can't reach its documented `200`),
mirroring how the team-endpoints PR handled its protected routes; full coverage
lives in `routes/reports.spec.ts`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)