### PR TITLE
feature(30) + [api] implement auth endpoints

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -11,6 +11,12 @@ POSTGRES_PORT=5432
 # compose service name `postgres`; use `localhost` if you run them on the host.
 DATABASE_URL=postgres://schediochron:schediochron@postgres:5432/schediochron
 
+# Auth (ADR-003). ACCESS_TOKEN_SECRET signs access-token JWTs and has no default
+# — set it to a long random string. REFRESH_TOKEN_TTL_SECONDS is the refresh
+# token lifetime; it defaults to 30 days when unset.
+ACCESS_TOKEN_SECRET=change-me-to-a-long-random-secret
+REFRESH_TOKEN_TTL_SECONDS=2592000
+
 # Host ports the API and web dev server are published on.
 API_PORT=3000
 WEB_PORT=4200

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -60,6 +60,8 @@ services:
     environment:
       PORT: '3000'
       DATABASE_URL: ${DATABASE_URL:-postgres://schediochron:schediochron@postgres:5432/schediochron}
+      ACCESS_TOKEN_SECRET: ${ACCESS_TOKEN_SECRET:-change-me-to-a-long-random-secret}
+      REFRESH_TOKEN_TTL_SECONDS: ${REFRESH_TOKEN_TTL_SECONDS:-2592000}
     ports:
       - '${API_PORT:-3000}:3000'
     volumes:

--- a/libs/api/src/app.spec.ts
+++ b/libs/api/src/app.spec.ts
@@ -19,11 +19,10 @@ describe('GET /health', () => {
  * method fails here rather than in the per-resource shape specs.
  */
 const operations = [
-  { id: 'registerUser', method: 'POST', path: '/auth/register', status: 201 },
-  { id: 'loginUser', method: 'POST', path: '/auth/login', status: 200 },
-  { id: 'refreshToken', method: 'POST', path: '/auth/refresh', status: 200 },
-  { id: 'logoutUser', method: 'POST', path: '/auth/logout', status: 204 },
-
+  // The /auth operations are backed by the database (or, for logout,
+  // authenticated) now, so they no longer return their documented status to
+  // this unauthenticated, DB-less smoke table. Their routing, statuses, and
+  // auth are covered end-to-end in routes/auth.spec.ts.
   { id: 'listUsers', method: 'GET', path: '/users', status: 200 },
   { id: 'getUser', method: 'GET', path: '/users/u-1', status: 200 },
   { id: 'updateUser', method: 'PATCH', path: '/users/u-1', status: 200 },
@@ -86,7 +85,7 @@ const operations = [
 describe('openapi.yaml operations', () => {
   it('covers every documented operation', () => {
     // Guards against an endpoint being dropped from the table along with its route.
-    expect(operations).toHaveLength(23);
+    expect(operations).toHaveLength(19);
   });
 
   for (const { id, method, path, status } of operations) {
@@ -123,7 +122,9 @@ describe('unrouted requests', () => {
   });
 
   it('returns 404 for a method the path does not define', async () => {
-    const res = await app.request('/auth/register', { method: 'DELETE' });
+    // /health is defined for GET only and carries no data middleware, so a
+    // DELETE exercises method-not-defined routing without touching the database.
+    const res = await app.request('/health', { method: 'DELETE' });
 
     expect(res.status).toBe(404);
   });

--- a/libs/api/src/auth/refresh-tokens.ts
+++ b/libs/api/src/auth/refresh-tokens.ts
@@ -1,0 +1,76 @@
+import { randomBytes, randomUUID } from 'node:crypto';
+import type { RefreshToken } from '@schediochron/core';
+
+/**
+ * Refresh-token minting and hashing (ADR-003).
+ *
+ * Refresh tokens are opaque random strings. The value handed to the client is
+ * never stored; only its SHA-256 hash is persisted, so a leaked database cannot
+ * be replayed against the refresh endpoint. Lookups hash the incoming token and
+ * compare hashes. This module owns both halves — generate + hash — so the route
+ * never handles the raw token past the response it returns.
+ */
+
+const TTL_ENV = 'REFRESH_TOKEN_TTL_SECONDS';
+const DEFAULT_TTL_SECONDS = 30 * 24 * 60 * 60; // 30 days
+
+/**
+ * Refresh-token lifetime in seconds, from `REFRESH_TOKEN_TTL_SECONDS` (a config
+ * concern per ADR-003), defaulting to 30 days. The refresh token carries the
+ * long-lived session; the access token stays short.
+ */
+export function getRefreshTokenTtlSeconds(): number {
+  const raw = process.env[TTL_ENV];
+  if (raw === undefined) {
+    return DEFAULT_TTL_SECONDS;
+  }
+  const seconds = Number(raw);
+  if (!Number.isInteger(seconds) || seconds <= 0) {
+    throw new Error(
+      `${TTL_ENV} must be a positive integer of seconds, got "${raw}"`,
+    );
+  }
+  return seconds;
+}
+
+/** Generates an opaque refresh token with ample entropy (UUID + 32 bytes). */
+export function generateRefreshToken(): string {
+  return `${randomUUID()}.${randomBytes(32).toString('hex')}`;
+}
+
+/** The SHA-256 hash (hex) of an opaque token — the value stored server-side. */
+export function hashRefreshToken(token: string): string {
+  return new Bun.CryptoHasher('sha256').update(token).digest('hex');
+}
+
+/** An opaque token to hand the client, paired with the record to persist. */
+export interface MintedRefreshToken {
+  /** The opaque value returned to the client. Never stored. */
+  opaqueToken: string;
+  /** The record to persist — `token` is the hash, not the opaque value. */
+  record: RefreshToken;
+}
+
+/**
+ * Mints a fresh refresh token for the user: a random opaque value for the
+ * client and a persistable record holding only its hash, with an expiry set
+ * from the configured TTL and `revokedAt` null.
+ */
+export function mintRefreshToken(
+  userId: string,
+  now: Date = new Date(),
+): MintedRefreshToken {
+  const opaqueToken = generateRefreshToken();
+  const expiresAt = new Date(
+    now.getTime() + getRefreshTokenTtlSeconds() * 1000,
+  ).toISOString();
+  return {
+    opaqueToken,
+    record: {
+      token: hashRefreshToken(opaqueToken),
+      userId,
+      expiresAt,
+      revokedAt: null,
+    },
+  };
+}

--- a/libs/api/src/repositories.ts
+++ b/libs/api/src/repositories.ts
@@ -1,15 +1,19 @@
 import type { SQL } from 'bun';
 import type { MiddlewareHandler } from 'hono';
 import type {
+  RefreshTokenRepository,
   TeamRepository,
   TimeEntryRepository,
   UserRepository,
 } from '@schediochron/core';
 import {
+  SqlPasswordCredentialStore,
+  SqlRefreshTokenRepository,
   SqlTimeEntryRepository,
   SqlTeamRepository,
   SqlUserRepository,
   createSqlClient,
+  type PasswordCredentialStore,
 } from '@schediochron/sql';
 
 /**
@@ -28,6 +32,10 @@ export interface Repositories {
   users: UserRepository;
   timeEntries: TimeEntryRepository;
   teams: TeamRepository;
+  /** Server-side refresh-token store — revocation and rotation for auth (#30). */
+  refreshTokens: RefreshTokenRepository;
+  /** Password-hash store, keyed by user id — auth credentials (#30). */
+  credentials: PasswordCredentialStore;
 }
 
 // Type the context variable so `c.get('repositories')` is `Repositories`.
@@ -43,6 +51,8 @@ export function createRepositories(sql: SQL): Repositories {
     users: new SqlUserRepository(sql),
     timeEntries: new SqlTimeEntryRepository(sql),
     teams: new SqlTeamRepository(sql),
+    refreshTokens: new SqlRefreshTokenRepository(sql),
+    credentials: new SqlPasswordCredentialStore(sql),
   };
 }
 

--- a/libs/api/src/routes/auth.spec.ts
+++ b/libs/api/src/routes/auth.spec.ts
@@ -1,36 +1,319 @@
-import { describe, expect, it } from 'bun:test';
+import { afterEach, beforeEach, describe, expect, it } from 'bun:test';
+import type {
+  RefreshToken,
+  RefreshTokenRepository,
+  User,
+  UserRepository,
+} from '@schediochron/core';
 import { validateUser } from '@schediochron/core';
+import {
+  DuplicateUserError,
+  type PasswordCredentialStore,
+} from '@schediochron/sql';
 import { app } from '../app.js';
+import { setRepositories, type Repositories } from '../repositories.js';
+import { hashRefreshToken } from '../auth/refresh-tokens.js';
+
+// Real signing and real Bun.password are used; only persistence is faked.
+process.env.ACCESS_TOKEN_SECRET = 'test-secret-for-auth-endpoints';
+
+// --- In-memory fakes -------------------------------------------------------
+
+class FakeUserRepository implements UserRepository {
+  private readonly byId = new Map<string, User>();
+
+  async findById(id: string): Promise<User | null> {
+    return this.byId.get(id) ?? null;
+  }
+
+  async findByUsername(username: string): Promise<User | null> {
+    for (const user of this.byId.values()) {
+      if (user.username === username) return user;
+    }
+    return null;
+  }
+
+  async findAll(): Promise<User[]> {
+    return [...this.byId.values()];
+  }
+
+  async create(item: User): Promise<User> {
+    for (const user of this.byId.values()) {
+      if (user.username === item.username) {
+        throw new DuplicateUserError('username');
+      }
+      if (item.email !== null && user.email === item.email) {
+        throw new DuplicateUserError('email');
+      }
+    }
+    const now = new Date().toISOString();
+    const stored: User = { ...item, createdAt: now, updatedAt: now };
+    this.byId.set(stored.id, stored);
+    return stored;
+  }
+
+  async update(item: User): Promise<User> {
+    this.byId.set(item.id, item);
+    return item;
+  }
+
+  async delete(id: string): Promise<void> {
+    this.byId.delete(id);
+  }
+}
+
+class FakeCredentialStore implements PasswordCredentialStore {
+  private readonly byUser = new Map<string, string>();
+
+  async set(userId: string, passwordHash: string): Promise<void> {
+    this.byUser.set(userId, passwordHash);
+  }
+
+  async findPasswordHash(userId: string): Promise<string | null> {
+    return this.byUser.get(userId) ?? null;
+  }
+}
+
+class FakeRefreshTokenRepository implements RefreshTokenRepository {
+  private readonly byToken = new Map<string, RefreshToken>();
+
+  async create(token: RefreshToken): Promise<RefreshToken> {
+    this.byToken.set(token.token, token);
+    return token;
+  }
+
+  async findByToken(token: string): Promise<RefreshToken | null> {
+    return this.byToken.get(token) ?? null;
+  }
+
+  async revoke(token: string): Promise<void> {
+    const found = this.byToken.get(token);
+    if (found && found.revokedAt === null) {
+      this.byToken.set(token, {
+        ...found,
+        revokedAt: new Date().toISOString(),
+      });
+    }
+  }
+
+  async revokeAllForUser(userId: string): Promise<void> {
+    for (const [key, token] of this.byToken) {
+      if (token.userId === userId && token.revokedAt === null) {
+        this.byToken.set(key, {
+          ...token,
+          revokedAt: new Date().toISOString(),
+        });
+      }
+    }
+  }
+
+  /** Test-only: insert a record verbatim (e.g. an already-expired token). */
+  seed(token: RefreshToken): void {
+    this.byToken.set(token.token, token);
+  }
+}
+
+let refreshTokens: FakeRefreshTokenRepository;
+
+function installFakes(): void {
+  refreshTokens = new FakeRefreshTokenRepository();
+  const repos: Repositories = {
+    users: new FakeUserRepository(),
+    credentials: new FakeCredentialStore(),
+    refreshTokens,
+    // Unused by the auth routes.
+    teams: undefined as unknown as Repositories['teams'],
+    timeEntries: undefined as unknown as Repositories['timeEntries'],
+  };
+  setRepositories(repos);
+}
+
+const jsonRequest = (
+  path: string,
+  body: unknown,
+  headers: Record<string, string> = {},
+) =>
+  app.request(path, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json', ...headers },
+    body: JSON.stringify(body),
+  });
+
+async function register(
+  username = 'ada_lovelace',
+  password = 'correct horse',
+): Promise<{ accessToken: string; refreshToken: string; user: User }> {
+  const res = await jsonRequest('/auth/register', { username, password });
+  return (await res.json()) as {
+    accessToken: string;
+    refreshToken: string;
+    user: User;
+  };
+}
+
+// --- Tests -----------------------------------------------------------------
+
+beforeEach(() => {
+  installFakes();
+});
+
+afterEach(() => {
+  setRepositories(undefined);
+});
 
 describe('POST /auth/register', () => {
-  it('returns a valid user and a token pair', async () => {
-    const res = await app.request('/auth/register', { method: 'POST' });
-    const body = (await res.json()) as Record<string, unknown>;
+  it('creates a user, returns 201 with a token pair and no passwordHash', async () => {
+    const res = await jsonRequest('/auth/register', {
+      username: 'ada_lovelace',
+      password: 'correct horse',
+      displayName: 'Ada',
+    });
+    expect(res.status).toBe(201);
 
+    const body = (await res.json()) as Record<string, unknown>;
     expect(validateUser(body['user']).success).toBe(true);
+    expect(
+      (body['user'] as Record<string, unknown>)['passwordHash'],
+    ).toBeUndefined();
     expect(typeof body['accessToken']).toBe('string');
     expect(typeof body['refreshToken']).toBe('string');
+  });
+
+  it('returns 400 on a validation failure (short password)', async () => {
+    const res = await jsonRequest('/auth/register', {
+      username: 'ada_lovelace',
+      password: 'short',
+    });
+    expect(res.status).toBe(400);
+  });
+
+  it('returns 409 on a duplicate username', async () => {
+    await register('ada_lovelace');
+    const res = await jsonRequest('/auth/register', {
+      username: 'ada_lovelace',
+      password: 'another password',
+    });
+    expect(res.status).toBe(409);
+  });
+
+  it('returns 409 on a duplicate email', async () => {
+    await jsonRequest('/auth/register', {
+      username: 'ada_lovelace',
+      password: 'correct horse',
+      email: 'ada@example.com',
+    });
+    const res = await jsonRequest('/auth/register', {
+      username: 'grace_hopper',
+      password: 'correct horse',
+      email: 'ada@example.com',
+    });
+    expect(res.status).toBe(409);
   });
 });
 
 describe('POST /auth/login', () => {
-  it('returns a valid user and a token pair', async () => {
-    const res = await app.request('/auth/login', { method: 'POST' });
-    const body = (await res.json()) as Record<string, unknown>;
+  it('authenticates by username and returns 200 with a token pair', async () => {
+    await register('ada_lovelace', 'correct horse');
+    const res = await jsonRequest('/auth/login', {
+      username: 'ada_lovelace',
+      password: 'correct horse',
+    });
+    expect(res.status).toBe(200);
 
+    const body = (await res.json()) as Record<string, unknown>;
     expect(validateUser(body['user']).success).toBe(true);
     expect(typeof body['accessToken']).toBe('string');
     expect(typeof body['refreshToken']).toBe('string');
   });
+
+  it('returns 401 on a wrong password', async () => {
+    await register('ada_lovelace', 'correct horse');
+    const res = await jsonRequest('/auth/login', {
+      username: 'ada_lovelace',
+      password: 'wrong password',
+    });
+    expect(res.status).toBe(401);
+  });
+
+  it('returns 401 for an unknown user', async () => {
+    const res = await jsonRequest('/auth/login', {
+      username: 'nobody',
+      password: 'correct horse',
+    });
+    expect(res.status).toBe(401);
+  });
 });
 
 describe('POST /auth/refresh', () => {
-  it('returns a token pair without a user', async () => {
-    const res = await app.request('/auth/refresh', { method: 'POST' });
-    const body = (await res.json()) as Record<string, unknown>;
+  it('exchanges a valid refresh token for a new token pair (200)', async () => {
+    const { refreshToken } = await register();
+    const res = await jsonRequest('/auth/refresh', { refreshToken });
+    expect(res.status).toBe(200);
 
+    const body = (await res.json()) as Record<string, unknown>;
     expect(typeof body['accessToken']).toBe('string');
     expect(typeof body['refreshToken']).toBe('string');
     expect(body['user']).toBeUndefined();
+    // Rotation: the returned token differs from the presented one.
+    expect(body['refreshToken']).not.toBe(refreshToken);
+  });
+
+  it('returns 401 when the same token is reused after rotation', async () => {
+    const { refreshToken } = await register();
+    await jsonRequest('/auth/refresh', { refreshToken });
+    const res = await jsonRequest('/auth/refresh', { refreshToken });
+    expect(res.status).toBe(401);
+  });
+
+  it('returns 401 for an expired refresh token', async () => {
+    const { refreshToken, user } = await register();
+    // Force the stored record to be expired.
+    refreshTokens.seed({
+      token: hashRefreshToken(refreshToken),
+      userId: user.id,
+      expiresAt: new Date(Date.now() - 1000).toISOString(),
+      revokedAt: null,
+    });
+    const res = await jsonRequest('/auth/refresh', { refreshToken });
+    expect(res.status).toBe(401);
+  });
+
+  it('returns 401 for an unknown refresh token', async () => {
+    const res = await jsonRequest('/auth/refresh', {
+      refreshToken: 'never-issued',
+    });
+    expect(res.status).toBe(401);
+  });
+});
+
+describe('POST /auth/logout', () => {
+  it('requires authentication (401 without a bearer token)', async () => {
+    const { refreshToken } = await register();
+    const res = await jsonRequest('/auth/logout', { refreshToken });
+    expect(res.status).toBe(401);
+  });
+
+  it('revokes the refresh token: logout then refresh returns 401', async () => {
+    const { accessToken, refreshToken } = await register();
+
+    const logout = await jsonRequest(
+      '/auth/logout',
+      { refreshToken },
+      { Authorization: `Bearer ${accessToken}` },
+    );
+    expect(logout.status).toBe(204);
+
+    const refresh = await jsonRequest('/auth/refresh', { refreshToken });
+    expect(refresh.status).toBe(401);
+  });
+
+  it('is idempotent — logging out an unknown token still returns 204', async () => {
+    const { accessToken } = await register();
+    const res = await jsonRequest(
+      '/auth/logout',
+      { refreshToken: 'never-issued' },
+      { Authorization: `Bearer ${accessToken}` },
+    );
+    expect(res.status).toBe(204);
   });
 });

--- a/libs/api/src/routes/auth.ts
+++ b/libs/api/src/routes/auth.ts
@@ -1,16 +1,182 @@
-import type { AuthResponse } from '@schediochron/core';
-import { createRouter } from '../http.js';
-import { stubTokenPair, stubUser } from '../stub-data.js';
+import { randomUUID } from 'node:crypto';
+import type { Context } from 'hono';
+import type { AuthResponse, TokenPair, User } from '@schediochron/core';
+import { isRefreshTokenActive } from '@schediochron/core';
+import { DuplicateUserError } from '@schediochron/sql';
+import {
+  badRequest,
+  conflict,
+  createRouter,
+  formatZodIssues,
+  unauthorized,
+} from '../http.js';
+import {
+  loginRequestSchema,
+  logoutRequestSchema,
+  refreshRequestSchema,
+  registerRequestSchema,
+} from '../schemas.js';
+import { provideRepositories, type Repositories } from '../repositories.js';
+import { requireAuth } from '../auth/middleware.js';
+import { signAccessToken } from '../auth/tokens.js';
+import { hashRefreshToken, mintRefreshToken } from '../auth/refresh-tokens.js';
 
-/** `/auth` — authentication and token management. Stub responses (#83). */
+/**
+ * `/auth` — authentication and token management (ADR-003), backed by the
+ * database via the repository seam (#30).
+ *
+ * Register, login, and refresh are public; only logout is behind `requireAuth`.
+ * Passwords are hashed with `Bun.password` (argon2id). Refresh tokens are opaque
+ * random strings stored only as their SHA-256 hash, revocable on logout and
+ * rotated on refresh; `passwordHash` never leaves the persistence layer.
+ */
 export const authRoutes = createRouter();
 
-const authResponse: AuthResponse = { user: stubUser, ...stubTokenPair };
+authRoutes.use('*', provideRepositories);
+// register / login / refresh are public; protect only logout.
+authRoutes.use('/logout', requireAuth);
 
-authRoutes.post('/register', (c) => c.json(authResponse, 201));
+/**
+ * Reads and JSON-parses the request body, returning `null` on a malformed body
+ * so the caller can answer 400 rather than let the parse error escape.
+ */
+async function readJsonBody(c: Context): Promise<unknown | null> {
+  try {
+    return (await c.req.json()) as unknown;
+  } catch {
+    return null;
+  }
+}
 
-authRoutes.post('/login', (c) => c.json(authResponse, 200));
+/**
+ * Issues a fresh token pair for the user: a signed access token plus a newly
+ * minted refresh token whose hash is persisted for later revocation.
+ */
+async function issueTokenPair(
+  repos: Repositories,
+  user: Pick<User, 'id' | 'username' | 'role'>,
+): Promise<TokenPair> {
+  const accessToken = await signAccessToken({
+    id: user.id,
+    username: user.username,
+    role: user.role,
+  });
+  const minted = mintRefreshToken(user.id);
+  await repos.refreshTokens.create(minted.record);
+  return { accessToken, refreshToken: minted.opaqueToken };
+}
 
-authRoutes.post('/refresh', (c) => c.json(stubTokenPair, 200));
+// --- POST /auth/register (201, public) ---
+authRoutes.post('/register', async (c) => {
+  const body = await readJsonBody(c);
+  const parsed = registerRequestSchema.safeParse(body);
+  if (!parsed.success) {
+    return badRequest(c, 'Validation failed', formatZodIssues(parsed.error));
+  }
+  const { username, password, displayName, email } = parsed.data;
 
-authRoutes.post('/logout', (c) => c.body(null, 204));
+  const passwordHash = await Bun.password.hash(password);
+  const repos = c.get('repositories');
+
+  let user: User;
+  try {
+    user = await repos.users.create({
+      id: randomUUID(),
+      username,
+      displayName: displayName ?? null,
+      email: email ?? null,
+      role: 'member',
+      // createdAt/updatedAt are set by the persistence layer on write.
+      createdAt: '',
+      updatedAt: '',
+    });
+  } catch (err) {
+    if (err instanceof DuplicateUserError) {
+      return conflict(c, `The ${err.field} is already taken`);
+    }
+    throw err;
+  }
+
+  // The user row exists; write its credential. A user without a credential
+  // simply cannot authenticate (ADR-002), so this is safe to do as a second
+  // write rather than one transaction across the repository seam.
+  await repos.credentials.set(user.id, passwordHash);
+
+  const tokens = await issueTokenPair(repos, user);
+  const response: AuthResponse = { user, ...tokens };
+  return c.json(response, 201);
+});
+
+// --- POST /auth/login (200, public, by username) ---
+authRoutes.post('/login', async (c) => {
+  const body = await readJsonBody(c);
+  const parsed = loginRequestSchema.safeParse(body);
+  if (!parsed.success) {
+    return badRequest(c, 'Validation failed', formatZodIssues(parsed.error));
+  }
+  const { username, password } = parsed.data;
+  const repos = c.get('repositories');
+
+  // Do not distinguish which of the two was wrong: unknown user, missing
+  // credential, and bad password all answer the same 401.
+  const user = await repos.users.findByUsername(username);
+  if (!user) {
+    return unauthorized(c, 'Invalid username or password');
+  }
+  const passwordHash = await repos.credentials.findPasswordHash(user.id);
+  if (!passwordHash) {
+    return unauthorized(c, 'Invalid username or password');
+  }
+  const ok = await Bun.password.verify(password, passwordHash);
+  if (!ok) {
+    return unauthorized(c, 'Invalid username or password');
+  }
+
+  const tokens = await issueTokenPair(repos, user);
+  const response: AuthResponse = { user, ...tokens };
+  return c.json(response, 200);
+});
+
+// --- POST /auth/refresh (200, public) ---
+authRoutes.post('/refresh', async (c) => {
+  const body = await readJsonBody(c);
+  const parsed = refreshRequestSchema.safeParse(body);
+  if (!parsed.success) {
+    return badRequest(c, 'Validation failed', formatZodIssues(parsed.error));
+  }
+  const repos = c.get('repositories');
+
+  const hash = hashRefreshToken(parsed.data.refreshToken);
+  const stored = await repos.refreshTokens.findByToken(hash);
+  if (!stored || !isRefreshTokenActive(stored)) {
+    return unauthorized(c, 'Refresh token not found, expired, or revoked');
+  }
+
+  // The access token carries username and role, which the token record does
+  // not, so load the user. A token for a deleted user is unusable.
+  const user = await repos.users.findById(stored.userId);
+  if (!user) {
+    return unauthorized(c, 'Refresh token not found, expired, or revoked');
+  }
+
+  // Rotate (ADR-003): mint a new refresh token and revoke the presented one, so
+  // a leaked token is single-use.
+  const tokens = await issueTokenPair(repos, user);
+  await repos.refreshTokens.revoke(hash);
+  return c.json(tokens satisfies TokenPair, 200);
+});
+
+// --- POST /auth/logout (204, protected) ---
+authRoutes.post('/logout', async (c) => {
+  const body = await readJsonBody(c);
+  const parsed = logoutRequestSchema.safeParse(body);
+  if (!parsed.success) {
+    return badRequest(c, 'Validation failed', formatZodIssues(parsed.error));
+  }
+  const repos = c.get('repositories');
+
+  // Revoking an unknown or already-revoked token is a no-op; logout is
+  // idempotent and always answers 204.
+  await repos.refreshTokens.revoke(hashRefreshToken(parsed.data.refreshToken));
+  return c.body(null, 204);
+});

--- a/libs/sql/src/index.ts
+++ b/libs/sql/src/index.ts
@@ -25,3 +25,8 @@ export type { DuplicateUserField } from './user-repository.js';
 export { DuplicateUserError, SqlUserRepository } from './user-repository.js';
 
 export { SqlTeamRepository, LastAdminError } from './team-repository.js';
+
+export { SqlRefreshTokenRepository } from './refresh-token-repository.js';
+
+export type { PasswordCredentialStore } from './password-credential-store.js';
+export { SqlPasswordCredentialStore } from './password-credential-store.js';

--- a/libs/sql/src/password-credential-store.spec.ts
+++ b/libs/sql/src/password-credential-store.spec.ts
@@ -1,0 +1,53 @@
+import { afterAll, beforeAll, describe, expect, it } from 'bun:test';
+import { randomUUID } from 'node:crypto';
+import type { SQL } from 'bun';
+import { createSqlClient } from './db.js';
+import { migrateUp } from './migrate.js';
+import { SqlPasswordCredentialStore } from './password-credential-store.js';
+
+// DB-backed round-trips. There is no live PostgreSQL in CI/dev here, so these
+// skip unless DATABASE_URL points at a disposable database.
+describe.skipIf(!process.env.DATABASE_URL)(
+  'SqlPasswordCredentialStore (PostgreSQL)',
+  () => {
+    let sql: SQL;
+    let store: SqlPasswordCredentialStore;
+
+    async function makeUser(): Promise<string> {
+      const id = randomUUID();
+      await sql`
+        INSERT INTO users (id, username, role)
+        VALUES (${id}, ${`cred_${id.slice(0, 8)}`}, 'member')
+      `;
+      return id;
+    }
+
+    beforeAll(async () => {
+      sql = createSqlClient();
+      await migrateUp(sql);
+      store = new SqlPasswordCredentialStore(sql);
+    });
+
+    afterAll(async () => {
+      await sql?.close();
+    });
+
+    it('returns null when the user has no credential', async () => {
+      const userId = await makeUser();
+      expect(await store.findPasswordHash(userId)).toBeNull();
+    });
+
+    it('set writes the hash and findPasswordHash reads it back', async () => {
+      const userId = await makeUser();
+      await store.set(userId, 'hash-one');
+      expect(await store.findPasswordHash(userId)).toBe('hash-one');
+    });
+
+    it('set upserts — a second write replaces the hash in place', async () => {
+      const userId = await makeUser();
+      await store.set(userId, 'hash-one');
+      await store.set(userId, 'hash-two');
+      expect(await store.findPasswordHash(userId)).toBe('hash-two');
+    });
+  },
+);

--- a/libs/sql/src/password-credential-store.ts
+++ b/libs/sql/src/password-credential-store.ts
@@ -1,0 +1,61 @@
+import type { SQL } from 'bun';
+
+/**
+ * Server-side store for a user's password hash.
+ *
+ * `@schediochron/core` deliberately has no credential repository: the `User`
+ * model and its repository are credential-free by design (ADR-002 — the hash
+ * lives "only in the persistence layer", never on `User`). This interface is
+ * therefore defined here, in the persistence adapter, rather than in core. It is
+ * hash-agnostic: what a `passwordHash` string contains (argon2id, bcrypt, …) is
+ * the auth layer's concern; this store only persists and retrieves it.
+ */
+export interface PasswordCredentialStore {
+  /**
+   * Writes the user's password hash, replacing any existing one (upsert). Used
+   * both at registration and on password reset.
+   */
+  set(userId: string, passwordHash: string): Promise<void>;
+
+  /**
+   * The stored hash for the user, or `null` when the user has no credential —
+   * a user row may exist before a credential is written (ADR-002).
+   */
+  findPasswordHash(userId: string): Promise<string | null>;
+}
+
+/** The `user_credentials` columns this store reads. */
+interface CredentialRow {
+  password_hash: string;
+}
+
+/**
+ * PostgreSQL-backed {@link PasswordCredentialStore} over the `user_credentials`
+ * table, using Bun's native SQL client.
+ *
+ * The table is keyed one-to-one on `user_id`, so `set` upserts: a first write
+ * inserts, a later write (password change/reset) overwrites in place and
+ * refreshes `updated_at`.
+ */
+export class SqlPasswordCredentialStore implements PasswordCredentialStore {
+  constructor(private readonly sql: SQL) {}
+
+  async set(userId: string, passwordHash: string): Promise<void> {
+    await this.sql`
+      INSERT INTO user_credentials (user_id, password_hash)
+      VALUES (${userId}, ${passwordHash})
+      ON CONFLICT (user_id) DO UPDATE
+        SET password_hash = EXCLUDED.password_hash,
+            updated_at = now()
+    `;
+  }
+
+  async findPasswordHash(userId: string): Promise<string | null> {
+    const rows = (await this.sql`
+      SELECT password_hash
+      FROM user_credentials
+      WHERE user_id = ${userId}
+    `) as CredentialRow[];
+    return rows.length ? rows[0].password_hash : null;
+  }
+}

--- a/libs/sql/src/refresh-token-repository.spec.ts
+++ b/libs/sql/src/refresh-token-repository.spec.ts
@@ -1,0 +1,118 @@
+import { afterAll, beforeAll, describe, expect, it } from 'bun:test';
+import { randomUUID } from 'node:crypto';
+import type { SQL } from 'bun';
+import { isRefreshTokenActive } from '@schediochron/core';
+import { createSqlClient } from './db.js';
+import { migrateUp } from './migrate.js';
+import { SqlRefreshTokenRepository } from './refresh-token-repository.js';
+
+// DB-backed round-trips. There is no live PostgreSQL in CI/dev here, so these
+// skip unless DATABASE_URL points at a disposable database.
+describe.skipIf(!process.env.DATABASE_URL)(
+  'SqlRefreshTokenRepository (PostgreSQL)',
+  () => {
+    let sql: SQL;
+    let repo: SqlRefreshTokenRepository;
+    let userId: string;
+
+    beforeAll(async () => {
+      sql = createSqlClient();
+      await migrateUp(sql);
+      repo = new SqlRefreshTokenRepository(sql);
+      // A refresh token references a user; make one to satisfy the FK.
+      userId = randomUUID();
+      await sql`
+        INSERT INTO users (id, username, role)
+        VALUES (${userId}, ${`rt_${userId.slice(0, 8)}`}, 'member')
+      `;
+    });
+
+    afterAll(async () => {
+      await sql?.close();
+    });
+
+    it('stores the token value as given and reads it back', async () => {
+      const token = `hash_${randomUUID()}`;
+      const expiresAt = new Date(Date.now() + 60_000).toISOString();
+      const created = await repo.create({
+        token,
+        userId,
+        expiresAt,
+        revokedAt: null,
+      });
+
+      expect(created.token).toBe(token);
+      expect(created.userId).toBe(userId);
+      expect(created.revokedAt).toBeNull();
+      // Timestamps come back as ISO 8601 UTC.
+      expect(created.expiresAt).toMatch(/Z$/);
+      expect(new Date(created.expiresAt).toISOString()).toBe(created.expiresAt);
+
+      const found = await repo.findByToken(token);
+      expect(found).toEqual(created);
+      expect(found && isRefreshTokenActive(found)).toBe(true);
+    });
+
+    it('returns null for an unknown token', async () => {
+      expect(await repo.findByToken(`missing_${randomUUID()}`)).toBeNull();
+    });
+
+    it('revoke sets revokedAt and makes the token inactive', async () => {
+      const token = `hash_${randomUUID()}`;
+      await repo.create({
+        token,
+        userId,
+        expiresAt: new Date(Date.now() + 60_000).toISOString(),
+        revokedAt: null,
+      });
+
+      await repo.revoke(token);
+
+      const found = await repo.findByToken(token);
+      expect(found?.revokedAt).not.toBeNull();
+      expect(found && isRefreshTokenActive(found)).toBe(false);
+    });
+
+    it('revoking an unknown or already-revoked token is a no-op', async () => {
+      // Unknown token: no throw.
+      await repo.revoke(`missing_${randomUUID()}`);
+
+      const token = `hash_${randomUUID()}`;
+      await repo.create({
+        token,
+        userId,
+        expiresAt: new Date(Date.now() + 60_000).toISOString(),
+        revokedAt: null,
+      });
+      await repo.revoke(token);
+      const firstRevokedAt = (await repo.findByToken(token))?.revokedAt;
+
+      // Second revoke must not move revokedAt.
+      await repo.revoke(token);
+      expect((await repo.findByToken(token))?.revokedAt).toBe(firstRevokedAt);
+    });
+
+    it('revokeAllForUser revokes every live token for the user', async () => {
+      const tokens = [
+        `hash_${randomUUID()}`,
+        `hash_${randomUUID()}`,
+        `hash_${randomUUID()}`,
+      ];
+      for (const token of tokens) {
+        await repo.create({
+          token,
+          userId,
+          expiresAt: new Date(Date.now() + 60_000).toISOString(),
+          revokedAt: null,
+        });
+      }
+
+      await repo.revokeAllForUser(userId);
+
+      for (const token of tokens) {
+        const found = await repo.findByToken(token);
+        expect(found?.revokedAt).not.toBeNull();
+      }
+    });
+  },
+);

--- a/libs/sql/src/refresh-token-repository.ts
+++ b/libs/sql/src/refresh-token-repository.ts
@@ -1,0 +1,81 @@
+import type { SQL } from 'bun';
+import type { RefreshToken, RefreshTokenRepository } from '@schediochron/core';
+
+/**
+ * The `refresh_tokens` row as Bun's SQL client hands it back: snake_case
+ * columns, `timestamptz` values as `Date` (occasionally a string depending on
+ * driver config, hence the union), `revoked_at` nullable.
+ */
+interface RefreshTokenRow {
+  token: string;
+  user_id: string;
+  expires_at: Date | string;
+  revoked_at: Date | string | null;
+}
+
+/** A `timestamptz` value from the driver as an ISO 8601 UTC string. */
+function dbTimestampToIso(value: Date | string): string {
+  return value instanceof Date
+    ? value.toISOString()
+    : new Date(value).toISOString();
+}
+
+/** Maps a stored row to the {@link RefreshToken} model exactly. */
+function mapRow(row: RefreshTokenRow): RefreshToken {
+  return {
+    token: row.token,
+    userId: row.user_id,
+    expiresAt: dbTimestampToIso(row.expires_at),
+    revokedAt:
+      row.revoked_at === null ? null : dbTimestampToIso(row.revoked_at),
+  };
+}
+
+/**
+ * PostgreSQL-backed {@link RefreshTokenRepository} over Bun's native SQL client.
+ *
+ * Hash-agnostic by design: the `token` value is stored and looked up exactly as
+ * given. The auth layer (#30) passes the SHA-256 hash of the opaque token the
+ * client holds, so this repository never sees or handles the raw token — it
+ * treats `token` as a plain lookup key. `revoke`/`revokeAllForUser` set
+ * `revoked_at = now()`; revoking an unknown or already-revoked token is a no-op.
+ */
+export class SqlRefreshTokenRepository implements RefreshTokenRepository {
+  constructor(private readonly sql: SQL) {}
+
+  async create(token: RefreshToken): Promise<RefreshToken> {
+    const rows = (await this.sql`
+      INSERT INTO refresh_tokens (token, user_id, expires_at, revoked_at)
+      VALUES (${token.token}, ${token.userId}, ${token.expiresAt}, ${token.revokedAt})
+      RETURNING token, user_id, expires_at, revoked_at
+    `) as RefreshTokenRow[];
+    return mapRow(rows[0]);
+  }
+
+  async findByToken(token: string): Promise<RefreshToken | null> {
+    const rows = (await this.sql`
+      SELECT token, user_id, expires_at, revoked_at
+      FROM refresh_tokens
+      WHERE token = ${token}
+    `) as RefreshTokenRow[];
+    return rows.length ? mapRow(rows[0]) : null;
+  }
+
+  async revoke(token: string): Promise<void> {
+    // Only flip a live token; revoking an unknown or already-revoked token is a
+    // no-op (the WHERE simply matches no rows).
+    await this.sql`
+      UPDATE refresh_tokens
+      SET revoked_at = now()
+      WHERE token = ${token} AND revoked_at IS NULL
+    `;
+  }
+
+  async revokeAllForUser(userId: string): Promise<void> {
+    await this.sql`
+      UPDATE refresh_tokens
+      SET revoked_at = now()
+      WHERE user_id = ${userId} AND revoked_at IS NULL
+    `;
+  }
+}


### PR DESCRIPTION
Closes #30. Stacked on the repository-injection seam (PR #137).

Real database-backed auth, plus the persistence it needs.

## Persistence (`@schediochron/sql`)
- `SqlRefreshTokenRepository` — the core `RefreshTokenRepository` over `refresh_tokens`; hash-agnostic (stores the value it's given).
- `SqlPasswordCredentialStore` — `user_credentials` (`set` upsert, `findPasswordHash`); the credential store the `User` model deliberately excludes.
- Both added to the API `Repositories` seam.

## Endpoints (`/auth`)
- **register** (201): `Bun.password.hash` (argon2id), create user (`member`), `DuplicateUserError`→409, store credential, issue tokens. `passwordHash` never returned.
- **login** (200, by username): generic **401** for unknown user / missing credential / bad password (no enumeration).
- **refresh** (200): looks up the incoming token by its hash, checks `isRefreshTokenActive`, **rotates** (mints new, revokes old) per ADR-003.
- **logout** (204, protected by `requireAuth`): revokes the presented refresh token; idempotent.

Refresh tokens are opaque random strings stored **only as their SHA-256 hash**. `ACCESS_TOKEN_SECRET` + `REFRESH_TOKEN_TTL_SECONDS` added to `.env.example`; `ACCESS_TOKEN_SECRET` passed to the api service in `docker-compose.yml`.

## Tests
Endpoint tests inject in-memory fake repos via `setRepositories` and use **real** `Bun.password` + real signing: register→201 with no `passwordHash`, duplicate→409, bad creds→401, and **logout→refresh→401**. sql DB tests are `skipIf(!DATABASE_URL)`.
- build / typecheck / lint ✅ · Prettier-clean
- sql: 25 pass / 40 skip / 0 fail · api: **127 pass, 0 fail**

## Notes
- Registration writes user → credential → tokens as sequential writes (not one transaction across the seam); a user without a credential simply can't authenticate (ADR-002). Noted as a possible follow-up.
- Includes the `Sql*Repository` rename from the seam (rebased on it); the `app.spec.ts` smoke-table trim (auth rows) is the shared merge-conflict site with the sibling endpoint PRs.
- _Finished from a subagent's near-complete branch after it hit the session limit just before verification._

🤖 Generated with [Claude Code](https://claude.com/claude-code)