### PR TITLE
chore c [api/sql] declare sql dependency and format migrate files

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -49,6 +49,7 @@
       "dependencies": {
         "@hono/zod-openapi": "^0.19.10",
         "@schediochron/core": "workspace:^",
+        "@schediochron/sql": "workspace:^",
         "hono": "^4.12.0",
         "tslib": "^2.3.0",
         "zod": "^3.24.0",

--- a/libs/api/package.json
+++ b/libs/api/package.json
@@ -21,6 +21,7 @@
   "dependencies": {
     "@hono/zod-openapi": "^0.19.10",
     "@schediochron/core": "workspace:^",
+    "@schediochron/sql": "workspace:^",
     "hono": "^4.12.0",
     "tslib": "^2.3.0",
     "zod": "^3.24.0"

--- a/libs/sql/src/migrate.spec.ts
+++ b/libs/sql/src/migrate.spec.ts
@@ -73,7 +73,9 @@ describe('discoverMigrations', () => {
       '0001_b.up.sql': '',
       '0001_b.down.sql': '',
     });
-    expect(() => discoverMigrations(dir)).toThrow(/Duplicate migration version/);
+    expect(() => discoverMigrations(dir)).toThrow(
+      /Duplicate migration version/,
+    );
   });
 });
 

--- a/libs/sql/src/migrate.ts
+++ b/libs/sql/src/migrate.ts
@@ -188,7 +188,9 @@ async function main(): Promise<void> {
       case 'down': {
         const steps = Number(process.argv[3] ?? '1');
         if (!Number.isInteger(steps) || steps < 1) {
-          throw new Error(`down expects a positive step count, got "${process.argv[3]}"`);
+          throw new Error(
+            `down expects a positive step count, got "${process.argv[3]}"`,
+          );
         }
         const reverted = await migrateDown(sql, steps);
         console.log(
@@ -205,7 +207,9 @@ async function main(): Promise<void> {
         break;
       }
       default:
-        console.info(`Unknown command "${command}". Use: up | down [n] | status`);
+        console.info(
+          `Unknown command "${command}". Use: up | down [n] | status`,
+        );
         process.exitCode = 1;
     }
   } finally {


### PR DESCRIPTION
Two small integration-cleanup items from the Phase 2 endpoint wave.

## Changes
1. **Declare `@schediochron/sql` in `@schediochron/api` dependencies.** The API imports it at runtime (`src/repositories.ts`, the injection seam) but it was only resolving via workspace hoisting — a standalone install/publish would fail. Per AGENTS.md's allowlist-honesty rule, runtime deps must be declared. (`bun install` reports no lockfile change — it was already the resolved graph, just undeclared.)
2. **Prettier on `libs/sql/src/migrate.ts` + `migrate.spec.ts`.** These landed in #25 without a format pass; purely cosmetic (`format:check` isn't CI-gated).

## Verification
- `bun run --filter @schediochron/api build` / `typecheck` / `lint` ✅
- `bun run --filter @schediochron/sql test` → 25 pass, 0 fail
- Prettier-clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)